### PR TITLE
Add missing packages to req

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,12 +16,15 @@ mypy-extensions==0.4.1
 mypy==0.701
 numpy
 python-dateutil==2.7.2
+python-Levenshtein==0.12.0
 s3transfer==0.3.3
 scikit-learn==0.23.1
 sentry-sdk==0.7.9
 six==1.11.0
 snowballstemmer==1.2.1
 spacy==2.0.12
+torch>=1.4.0
+torchvision>=0.5.0
 tqdm==4.41.1
 word2number==1.1
 transformers==3.3.1


### PR DESCRIPTION
# Description

As we removed conda-related installation instructions (`conda create -n droidlet_env python==3.7.4 pip numpy scikit-learn==0.19.1 pytorch torchvision`) from README, we should add those packages pre-installed in conda env in our old instructions to `requirements.txt`

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before: if user use a empty conda env and pip install, it would miss some packages like pytorch.

After: user should get all required packages just doing 'pip install -r requirements.txt' in an empty conda env.


# Testing

Tested locally and passed.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

