### PR TITLE
clean up exception handling and only safe-handle whitelisted Exceptions

### DIFF
--- a/base_agent/core.py
+++ b/base_agent/core.py
@@ -18,9 +18,6 @@ class BaseAgent:
                 self.step()
             except Exception as e:
                 self.handle_exception(e)
-                if os.getenv('DEVMODE'):
-                    # raise immediately in dev mode to catch and fix errors
-                    raise e
 
     def step(self):
         self.perceive()

--- a/base_agent/save_and_fetch_commands.py
+++ b/base_agent/save_and_fetch_commands.py
@@ -2,7 +2,6 @@
 Copyright (c) Facebook, Inc. and its affiliates.
 """
 import sqlite3
-from sqlite3 import Error
 import json
 
 
@@ -12,11 +11,7 @@ def create_connection(db_file):
     :param db_file: database file
     :return: Connection object or None
     """
-    conn = None
-    try:
-        conn = sqlite3.connect(db_file, check_same_thread=False)
-    except Error as e:
-        print(e)
+    conn = sqlite3.connect(db_file, check_same_thread=False)
 
     return conn
 
@@ -27,11 +22,8 @@ def create_table(conn, create_table_sql):
     :param create_table_sql: a CREATE TABLE statement
     :return:
     """
-    try:
-        c = conn.cursor()
-        c.execute(create_table_sql)
-    except Error as e:
-        print(e)
+    c = conn.cursor()
+    c.execute(create_table_sql)
 
 
 def create_all_tables(conn):

--- a/locobot/agent/perception/handlers/core.py
+++ b/locobot/agent/perception/handlers/core.py
@@ -28,16 +28,7 @@ class AbstractHandler:
         pass
 
     def __call__(self, *input):
-        try:
-            return self.handle(*input)
-        except Exception as e:
-            logging.warning(
-                "Exception raised in {}. \n{}".format(self.__class__.__name__, e), exc_info=True
-            )
-            if os.getenv("DEVMODE"):
-                # raise immediately in dev mode to catch and fix errors
-                raise e
-            return
+        return self.handle(*input)
 
     def _debug_draw(self, *input):
         """Implement this method to hold visualization details useful in

--- a/locobot/agent/perception/perception.py
+++ b/locobot/agent/perception/perception.py
@@ -106,7 +106,7 @@ class Process(multiprocessing.Process):
         except Exception as e:
             tb = traceback.format_exc()
             self._child_conn.send((e, tb))
-            # raise e  # You can still rise this exception if you need to
+            # raise e  # You can still raise this exception if you need to
 
     @property
     def exception(self):


### PR DESCRIPTION
# Description

The exception handling in `base_agent` was eating all fatal exceptions, even though the intention was to catch exceptions coming from modules with expected failures such as Dialog Parser / Interpreter of the form "I don't understand what you are trying to say" where there are just out-of-distribution issues in the NLP stack.

So, for example if the database failed or if the connection with the robot failed, the agent was like continuing as if nothing happened.

This cleans up stuff in a way that only whitelisted exceptions (currently only `ErrorWithResponse`) are eaten and everything else is re-raised.

A debug mode is allowed, called `DROIDLET_DEBUG_MODE=1` where all exceptions are eaten (i.e old behavior)

Fixes https://github.com/facebookresearch/droidlet/issues/54

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)

## Type of requested review

- [x] I want a thorough review of the implementation.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

