### PR TITLE
aggressively move inst_seg objects if there is any change to their bl…

### DIFF
--- a/craftassist/agent/low_level_perception.py
+++ b/craftassist/agent/low_level_perception.py
@@ -158,12 +158,13 @@ class LowLevelMCPerception:
         """if the block is changed, the old instance segmentation is considered no longer valid"""
         # get all associated instseg nodes
         # FIXME make this into a basic search
-        info = self.memory.get_instseg_object_ids_by_xyz(xyz)
-        if info and len(info) > 0:
-            # delete the InstSeg info on the loc of this block;
-            # the SQL triggers will remove the object if this was the last block
-            # of the inst_seg Node
-            self.memory.remove_voxel(xyz[0], xyz[1], xyz[2], "inst_seg")
+        inst_seg_memids = self.memory.get_instseg_object_ids_by_xyz(xyz)
+        if inst_seg_memids:
+            # delete the InstSeg, they are ephemeral and should be recomputed
+            # TODO/FIXME  more refined approach: if a block changes
+            # ask the models to recompute.  if the tags are the same, keep it
+            for i in inst_seg_memids:
+                self.memory.forget(i[0])
 
     # clean all this up...
     # eventually some conditions for not committing air/negative blocks


### PR DESCRIPTION
# Description

aggressively move inst_seg objects if there is any change to their blocks; fixes bug introduced in https://github.com/facebookresearch/droidlet/pull/30
## Type of change

Please check the options that are relevant.

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [X] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before, low level perception would try to remove an inst_seg only if it was empty.  inst_segs are supposed to be ephemeral, so any change should cause a recompute... nevertheless, it might be better to be more careful about removing the inst_seg memid entirely, and keep it if the tags are the same after re-computing on the modified blocks

# Testing

Manually tested; we should probably add some tests with perception enabled on the mc side
# Checklist:

- [X] I have performed manual end-to-end testing of the feature in my environment.
- [X] I have added Docstrings and comments to the code.
- [X] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have added relevant collaborators to review the PR before merge.

