### PR TITLE
Issues template change

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,10 +1,6 @@
 ## Type of Issue
 
-Select the type of issue:
-- [ ] Bug report (to report a bug)
-- [ ] Feature request (to request an additional feature)
-- [ ] Tracker (I am just using this as a tracker)
-- [ ] Documentation Ask
+Tag this issue with one of our Github labels from the Labels menu on the right hand side. For eg - bug reports (to report a bug), feature request (to request an additional feature), documentation (for documentation asks) etc.
 
 ## Description
 


### PR DESCRIPTION
# Description

Proposing that we use github labels for categorizing issues. It is an inbuilt filter on the site. For eg - just clicking on the documentation label pulls up all the documentation issues. We can even add custom labels - like `droidlet hack session` to file away issues for the hack session.

![image](https://user-images.githubusercontent.com/57542204/106655513-75f59e00-6567-11eb-8575-b1defa1daf2f.png)

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [x] Documentation only change

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.


