### PR TITLE
Dedup and strip long commands for templated and templated filters GT …

### DIFF
--- a/tools/data_processing_scripts/process_templated_for_gt.py
+++ b/tools/data_processing_scripts/process_templated_for_gt.py
@@ -1,5 +1,5 @@
 """
-This script scrapes player logs from S3 and grabs the commands that are most played.
+This script processes large files eg. templated generations to create ground truth annotations.
 """
 import argparse
 
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--output_path",
         type=str,
-        help="Where to write groound truth annootations to.",
+        help="Where to write groound truth annotations to.",
         default="craftassist/agent/datasets/ground_truth/datasets/templated.txt"
     )
     args = parser.parse_args()

--- a/tools/data_processing_scripts/process_templated_for_gt.py
+++ b/tools/data_processing_scripts/process_templated_for_gt.py
@@ -1,0 +1,49 @@
+"""
+This script scrapes player logs from S3 and grabs the commands that are most played.
+"""
+import argparse
+
+
+def remove_duplicates(input_path, output_path):
+    """Remove duplicate commands in dataset.
+    """
+    new_data = {}
+    with open(input_path) as fd:
+        data = fd.readlines()
+
+    for line in data:
+        command, action_dict = line.split("|")
+        words_arr = command.split(" ")
+        if command in new_data:
+            continue
+        # Skip long comomands and NOOPs
+        elif len(words_arr) > 6 or "NOOP" in line:
+            continue
+        else:
+            new_data[command] = action_dict
+
+    print(len(new_data))
+
+    with open(output_path, "w") as fd:
+        for command in new_data:
+            fd.write("{}|{}".format(command, new_data[command]))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input_path",
+        type=str,
+        help="File we want to process for use in ground truth annotations.",
+        # Assuming run from ~/droidlet
+        default="craftassist/agent/datasets/full_data/templated.txt"
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        help="Where to write groound truth annootations to.",
+        default="craftassist/agent/datasets/ground_truth/datasets/templated.txt"
+    )
+    args = parser.parse_args()
+    remove_duplicates(args.input_path, args.output_path)
+


### PR DESCRIPTION
# Description

A simple data processing script that filters large data files to create ground truth annotations.
- Deduplicate commands
- Remove long commands (>6 words)
- Remove NOOPs

Overview of templated data:
- 56% are unique commands
- 40% are short commands

Selected 10% of templated and 54% of templated filters for use in ground truth.

Fixes # (issue)
#20 

## Type of change
Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

