### PR TITLE
Moving the common socket event handler out to loco_mc_agent

### DIFF
--- a/craftassist/agent/craftassist_agent.py
+++ b/craftassist/agent/craftassist_agent.py
@@ -68,7 +68,6 @@ class CraftAssistAgent(LocoMCAgent):
         super(CraftAssistAgent, self).__init__(opts)
         self.no_default_behavior = opts.no_default_behavior
         self.point_targets = []
-        self.dashboard_chat = None
         self.last_chat_time = 0
         # areas must be perceived at each step
         # List of tuple (XYZ, radius), each defines a cube
@@ -120,44 +119,6 @@ class CraftAssistAgent(LocoMCAgent):
     def init_event_handlers(self):
         """Handle the socket events"""
         super().init_event_handlers()
-
-        @sio.on("sendCommandToAgent")
-        def send_text_command_to_agent(sid, command):
-            """Add the command to agent's incoming chats list and
-            send back the parse.
-            Args:
-                command: The input text command from dashboard player
-            Returns:
-                return back a socket emit with parse of command and success status
-            """
-            logging.info("in send_text_command_to_agent, got the command: %r" % (command))
-            agent_chat = (
-                "<dashboard> " + command
-            )  # the chat is coming from a player called "dashboard"
-            self.dashboard_chat = agent_chat
-            dialogue_manager = self.dialogue_manager
-            logical_form = {}
-            status = ""
-            try:
-                logical_form = dialogue_manager.get_logical_form(
-                    s=command, model=dialogue_manager.model
-                )
-                logging.info("logical form is : %r" % (logical_form))
-                status = "Sent successfully"
-            except:
-                logging.info("error in sending chat")
-                status = "Error in sending chat"
-            # update server memory
-            self.dashboard_memory["chatResponse"][command] = logical_form
-            self.dashboard_memory["chats"].pop(0)
-            self.dashboard_memory["chats"].append({"msg": command, "failed": False})
-            payload = {
-                "status": status,
-                "chat": command,
-                "chatResponse": self.dashboard_memory["chatResponse"][command],
-                "allChats": self.dashboard_memory["chats"],
-            }
-            sio.emit("setChatResponse", payload)
 
     def init_inventory(self):
         """Initialize the agent's inventory"""

--- a/locobot/agent/locobot_agent.py
+++ b/locobot/agent/locobot_agent.py
@@ -71,7 +71,6 @@ class LocobotAgent(LocoMCAgent):
         logging.info("LocobotAgent.__init__ started")
         self.opts = opts
         self.entityId = 0
-        self.dashboard_chat = None
         self.no_default_behavior = opts.no_default_behavior
         self.last_chat_time = -1000000000000
         self.name = name
@@ -120,38 +119,6 @@ class LocobotAgent(LocoMCAgent):
                         self.mover.bot.get_tilt() + 0.08
                     )
             self.mover.move_relative([movement])
-
-        @sio.on("sendCommandToAgent")
-        def send_text_command_to_agent(sid, command):
-            logging.info("in send_text_command_to_agent, got the command: %r" % (command))
-            agent_chat = (
-                "<dashboard> " + command
-            )  # the chat is coming from a player called "dashboard"
-            self.dashboard_chat = agent_chat
-            dialogue_manager = self.dialogue_manager
-            # send back the dictionary
-            logical_form = {}
-            status = ""
-            try:
-                logical_form = dialogue_manager.get_logical_form(
-                    s=command, model=dialogue_manager.model
-                )
-                logging.info("logical form is : %r" % (logical_form))
-                status = "Sent successfully"
-            except:
-                logging.info("error in sending chat")
-                status = "Error in sending chat"
-            # update server memory
-            self.dashboard_memory["chatResponse"][command] = logical_form
-            self.dashboard_memory["chats"].pop(0)
-            self.dashboard_memory["chats"].append({"msg": command, "failed": False})
-            payload = {
-                "status": status,
-                "chat": command,
-                "chatResponse": self.dashboard_memory["chatResponse"][command],
-                "allChats": self.dashboard_memory["chats"],
-            }
-            sio.emit("setChatResponse", payload)
 
     def init_memory(self):
         """Instantiates memory for the agent.


### PR DESCRIPTION
# Description

This PR refactors out the socket event handler for `sendCommandToAgent` from [craftassist](https://github.com/facebookresearch/droidlet/blob/main/craftassist/agent/craftassist_agent.py#L124) and [locobot](https://github.com/facebookresearch/droidlet/blob/main/locobot/agent/locobot_agent.py#L124) to `loco_mc_agent`.

Fixes: #86  

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

