### PR TITLE
Removing forced perceive from core controller step

### DIFF
--- a/base_agent/loco_mc_agent.py
+++ b/base_agent/loco_mc_agent.py
@@ -249,11 +249,7 @@ class LocoMCAgent(BaseAgent):
     def controller_step(self):
         """Process incoming chats and modify task stack"""
         raw_incoming_chats = self.get_incoming_chats()
-        # if raw_incoming_chats:
-        #     # force to get objects
-        #     self.perceive(force=True)
-        #     logging.info("Incoming chats: {}".format(raw_incoming_chats))
-
+        logging.info("Incoming chats: {}".format(raw_incoming_chats))
         incoming_chats = []
         for raw_chat in raw_incoming_chats:
             match = re.search("^<([^>]+)> (.*)", raw_chat)

--- a/base_agent/loco_mc_agent.py
+++ b/base_agent/loco_mc_agent.py
@@ -249,10 +249,10 @@ class LocoMCAgent(BaseAgent):
     def controller_step(self):
         """Process incoming chats and modify task stack"""
         raw_incoming_chats = self.get_incoming_chats()
-        if raw_incoming_chats:
-            # force to get objects
-            self.perceive(force=True)
-            logging.info("Incoming chats: {}".format(raw_incoming_chats))
+        # if raw_incoming_chats:
+        #     # force to get objects
+        #     self.perceive(force=True)
+        #     logging.info("Incoming chats: {}".format(raw_incoming_chats))
 
         incoming_chats = []
         for raw_chat in raw_incoming_chats:


### PR DESCRIPTION
# Description

* Changing the [core event loop](https://github.com/facebookresearch/droidlet/blob/9eee8a77db52e25e01cca552437567fdbb9114f6/base_agent/core.py#L22). Currently it does `perceive -> memory update -> controller_step -> perceive -> task step`, because of a forced perceive inside the `controller_step`. 
* This forced perceivemeans that all perception modules have to run again before the command can be executed. This leads to 10s of seconds of delay between typing the command and its execution on the locobot.
* This also seems like a bug since a forced perceive is also wrapped later in the same function in a [`perceive_during_step` variable](https://github.com/facebookresearch/droidlet/blob/9eee8a77db52e25e01cca552437567fdbb9114f6/base_agent/loco_mc_agent.py#L274)


## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Speeds up command execution and snappiness of the agent.

# Testing

Manually tested with some commands.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

