### PR TITLE
Enabling downloads by default

### DIFF
--- a/tools/data_scripts/compare_directory_hash.sh
+++ b/tools/data_scripts/compare_directory_hash.sh
@@ -36,27 +36,23 @@ compare_checksum() {
     then
         echo "Local $FOLDER directory is up to date."
     else
-	    maybe_download $FOLDER
+	    try_download $FOLDER
     fi
 }
 
-maybe_download() {
+try_download() {
     FOLDER=$1
-    echo "Local ${FOLDER} directory is out of sync. Would you like to download the updated files from AWS?"
-	read -p "Enter Y/N: " permission
-	echo $permission
-	if [ "$permission" == "Y" ] || [ "$permission" == "y" ] || [ "$permission" == "yes" ]; then
-		echo "Downloading ${FOLDER} directory"
-		SCRIPT_PATH="$ROOTDIR/tools/data_scripts/fetch_aws_models.sh"
-        if cmp -s $FOLDER "datasets"
-        then
-            SCRIPT_PATH="$ROOTDIR/tools/data_scripts/fetch_aws_datasets.sh"
-        fi
-		echo "Downloading using script " $SCRIPT_PATH
-		"$SCRIPT_PATH" "$AGENT"
-	else
-		echo "Warning: Outdated models can cause breakages in the repo."
-	fi
+    echo "*********************************************************************************************"
+    echo "Local ${FOLDER} directory is out of sync. Downloading latest. Use --dev to disable downloads."
+    echo "*********************************************************************************************"
+    echo "Downloading ${FOLDER} directory"
+    SCRIPT_PATH="$ROOTDIR/tools/data_scripts/fetch_aws_models.sh"
+    if cmp -s $FOLDER "datasets"
+    then
+        SCRIPT_PATH="$ROOTDIR/tools/data_scripts/fetch_aws_datasets.sh"
+    fi
+    echo "Downloading using script " $SCRIPT_PATH
+    "$SCRIPT_PATH" "$AGENT"
 }
 
 pushd $AGENT_PATH


### PR DESCRIPTION
# Description

As we discussed in the hack session, enabling model/dataset downloads by default. Use --dev to disable downloads.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

# Testing

![permy](https://user-images.githubusercontent.com/57542204/106870822-8ad54d00-669f-11eb-8ddf-ae3e61b349a9.png)

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

