### PR TITLE
[dashboard frontend] add more atomic events in dashboard and fix some bugs found in the process

### DIFF
--- a/dldashboard/web/src/MainPane.js
+++ b/dldashboard/web/src/MainPane.js
@@ -25,6 +25,7 @@ class MainPane extends React.Component {
       <div>
         <InteractApp stateManager={stateManager} />
         <LiveImage
+          type={"rgb"}
           height={320}
           width={320}
           offsetH={320 + 80}

--- a/dldashboard/web/src/StateManager.js
+++ b/dldashboard/web/src/StateManager.js
@@ -61,6 +61,9 @@ class StateManager {
     this.updateStateManagerMemory = this.updateStateManagerMemory.bind(this);
     this.keyHandler = this.keyHandler.bind(this);
     this.memory = this.initialMemoryState;
+    this.processRGB = this.processRGB.bind(this);
+    this.processDepth = this.processDepth.bind(this);
+    this.processObjects = this.processObjects.bind(this);
 
     let url = localStorage.getItem("server_url");
     if (url === "undefined" || url === undefined || url === null) {
@@ -120,6 +123,9 @@ class StateManager {
     socket.on("setChatResponse", this.setChatResponse);
     socket.on("sensor_payload", this.processSensorPayload);
     socket.on("updateState", this.updateStateManagerMemory);
+    socket.on("rgb", this.processRGB);
+    socket.on("depth", this.processDepth);
+    socket.on("objects", this.processObjects);
   }
 
   updateStateManagerMemory(data) {
@@ -208,6 +214,51 @@ class StateManager {
     }
   }
 
+  processRGB(res) {
+    let rgb = new Image();
+    rgb.src = "data:image/webp;base64," + res;
+    this.refs.forEach((ref) => {
+      if (ref instanceof LiveImage) {
+        if (ref.props.type === "rgb") {
+          ref.setState({
+            isLoaded: true,
+            rgb: rgb,
+          });
+        }
+      }
+    });
+  }
+
+  processDepth(res) {
+    let depth = new Image();
+    depth.src = "data:image/webp;base64," + res;
+    this.refs.forEach((ref) => {
+      if (ref instanceof LiveImage) {
+        if (ref.props.type === "depth") {
+          ref.setState({
+            isLoaded: true,
+            depth: depth,
+          });
+        }
+      }
+    });
+  }
+
+  processObjects(res) {
+    let rgb = new Image();
+    rgb.src = "data:image/webp;base64," + res.image.rgb;
+
+    this.refs.forEach((ref) => {
+      if (ref instanceof LiveObjects) {
+        ref.setState({
+          isLoaded: true,
+          objects: res.objects,
+          rgb: rgb,
+        });
+      }
+    });
+  }
+
   processSensorPayload(res) {
     let fps_time = performance.now();
     let fps = 1000 / (fps_time - this.fps_time);
@@ -217,7 +268,7 @@ class StateManager {
     let depth = new Image();
     depth.src = "data:image/webp;base64," + res.image.depth;
     let object_rgb = new Image();
-    if (res.object_image !== -1) {
+    if (res.object_image !== -1 && res.object_image !== undefined) {
       object_rgb.src = "data:image/webp;base64," + res.object_image.rgb;
     }
 
@@ -238,7 +289,7 @@ class StateManager {
           depth: depth,
         });
       } else if (ref instanceof LiveObjects || ref instanceof LiveHumans) {
-        if (res.object_image !== -1) {
+        if (res.object_image !== -1 && res.object_image !== undefined) {
           ref.setState({
             isLoaded: true,
             rgb: object_rgb,

--- a/dldashboard/web/src/components/LiveObjects.js
+++ b/dldashboard/web/src/components/LiveObjects.js
@@ -102,8 +102,12 @@ class LiveObjects extends React.Component {
       ]
     */
     var renderedObjects = [];
+    let parsed_objects = objects;
+    if (objects === null) {
+      parsed_objects = [];
+    }
     let j = 0;
-    objects.forEach((obj) => {
+    parsed_objects.forEach((obj) => {
       let obj_id = obj.id;
       let label = String(obj_id).concat(obj.label);
       let properties = obj.properties;


### PR DESCRIPTION
These atomic events are used in the tutorial

Do not merge this PR. Once the stack is approved, merge https://github.com/facebookresearch/droidlet/pull/133 instead.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #132 Add a Locobot + Habitat based tutorial
* #131 bug fixes in path handling
* #130 small refactor of DetectedObjectNode
* #129 carve out the dialog model into it's own little self-contained class
* #128 refactor locobot perception MemoryHandler, carve out Object deduplication into it's own handler
* #127 better variable naming
* #126 add silent mode to TrackingHandler
* #125 allow move_relative and move_absolute to also take single xyt, not just lists of xyt
* #124 remove incorrect gitiginore
* #123 [dashboard] new binary build
* **#122 [dashboard frontend] add more atomic events in dashboard and fix some bugs found in the process**
* #121 fix a race condition in dashboard backend startup

