### PR TITLE
allow move_relative and move_absolute to also take single xyt, not just lists of xyt

### DIFF
--- a/locobot/agent/locobot_mover.py
+++ b/locobot/agent/locobot_mover.py
@@ -22,6 +22,7 @@ from base_agent.argument_parser import ArgumentParser
 from prettytable import PrettyTable
 from perception import RGBDepth
 from objects import Marker, Pos
+from collections.abc import Iterable
 from locobot_mover_utils import (
     get_camera_angles,
     angle_diff,
@@ -170,6 +171,9 @@ class LoCoBotMover:
             xyt_positions: a list of relative (x,y,yaw) positions for the bot to execute.
             x,y,yaw are in the pyrobot's coordinates.
         """
+        if not isinstance(next(iter(xyt_positions)), Iterable):
+            # single xyt position given
+            xyt_positions = [xyt_positions]
         for xyt in xyt_positions:
             self.bot.go_to_relative(xyt, close_loop=self.close_loop)
             while not self.bot.command_finished():
@@ -185,6 +189,9 @@ class LoCoBotMover:
             xyt_positions: a list of (x_c,y_c,yaw) positions for the bot to move to.
             (x_c,y_c,yaw) are in the canonical world coordinates.
         """
+        if not isinstance(next(iter(xyt_positions)), Iterable):
+            # single xyt position given
+            xyt_positions = [xyt_positions]
         for xyt in xyt_positions:
             logging.info("Move absolute {}".format(xyt))
             self.bot.go_to_absolute(


### PR DESCRIPTION
Do not merge this PR. Once the stack is approved, merge https://github.com/facebookresearch/droidlet/pull/133 instead.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #132 Add a Locobot + Habitat based tutorial
* #131 bug fixes in path handling
* #130 small refactor of DetectedObjectNode
* #129 carve out the dialog model into it's own little self-contained class
* #128 refactor locobot perception MemoryHandler, carve out Object deduplication into it's own handler
* #127 better variable naming
* #126 add silent mode to TrackingHandler
* **#125 allow move_relative and move_absolute to also take single xyt, not just lists of xyt**
* #124 remove incorrect gitiginore
* #123 [dashboard] new binary build
* #122 [dashboard frontend] add more atomic events in dashboard and fix some bugs found in the process
* #121 fix a race condition in dashboard backend startup

