### PR TITLE
refactor locobot perception MemoryHandler, carve out Object deduplication into it's own handler

### DIFF
--- a/locobot/agent/perception/handlers/__init__.py
+++ b/locobot/agent/perception/handlers/__init__.py
@@ -6,6 +6,8 @@ from .laser_pointer import LaserPointerHandler
 from .tracker import TrackingHandler
 from .memory import MemoryHandler
 from .core import RGBDepth, WorldObject
+from .deduplicater import ObjectDeduplicationHandler
+from .core import RGBDepth
 
 __all__ = [
     InputHandler,
@@ -15,6 +17,7 @@ __all__ = [
     LaserPointerHandler,
     TrackingHandler,
     MemoryHandler,
+    ObjectDeduplicationHandler,
     RGBDepth,
     Human,
     HumanKeypoints,

--- a/locobot/agent/perception/handlers/deduplicater.py
+++ b/locobot/agent/perception/handlers/deduplicater.py
@@ -1,0 +1,111 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+"""
+from .core import AbstractHandler
+from locobot.agent.objects import AttributeDict
+import torch
+import torchvision.models as models
+import numpy as np
+import logging
+from torchvision import transforms
+
+class ObjectDeduplicationHandler(AbstractHandler):
+    """Class for deduplicating a given set of objects from a given set of existing objects
+
+    """
+
+    def __init__(self):
+        self.object_id_counter = 1
+        self.dedupe_model = models.resnet18(pretrained=True).cuda()
+        self.layer = self.dedupe_model._modules.get("avgpool")
+        self.dedupe_model.eval()
+        self.transforms = [
+            transforms.Normalize(mean=[0.485, 0.456, 0.406],
+                                              std=[0.229, 0.224, 0.225]),
+            transforms.ToTensor()
+        ]
+        self._temp_buffer = torch.zeros(512).pin_memory()
+        def copy_data(m, i, o):
+            self._temp_buffer.copy_(torch.flatten(o).data)
+        self.layer.register_forward_hook(copy_data)
+
+    def get_feature_repr(self, img):
+        normalize, to_tensor = self.transforms
+        t_img = normalize(to_tensor(img)).unsqueeze(0).cuda()
+
+        with torch.no_grad():
+            self.dedupe_model(t_img)
+        return self._temp_buffer.clone()
+
+    # Not accounting for moving objects
+    def is_match(self, score, dist):
+        score_thresh = 0.95
+        dist_thresh = 0.6
+        if score > score_thresh and dist > dist_thresh:
+            return False  # Similar object, different places.
+        elif score > score_thresh and dist < dist_thresh:
+            return True  # same object, same place
+        else:
+            return False
+
+    def is_novel(self, current_object, previous_objects):
+        """this is long-term tracking (not in-frame). it does some feature
+        matching to figure out if we've seen this exact instance of object
+        before.
+
+        It uses the cosine similarity of conv features and (separately),
+        distance between two previous_objects
+
+        Args:
+            current_object (WorldObject): current object to compare
+            previous_objects (List[WorldObject]): all previous objects to compare to
+            
+
+        """
+        current_object.feature_repr = self.get_feature_repr(current_object.get_masked_img())
+        cos = torch.nn.CosineSimilarity(dim=1)
+        is_novel = True
+
+        # Future = use all object features to calculate novelty
+        for previous_object in previous_objects:
+            if isinstance(previous_object, dict):
+                previous_object = AttributeDict(previous_object)
+            score = cos(previous_object.feature_repr.unsqueeze(0), current_object.feature_repr.unsqueeze(0))
+            dist = np.linalg.norm(np.asarray(current_object.xyz[:2]) - np.asarray(previous_object.xyz[:2]))
+            logging.debug(
+                "Similarity {}.{} = {}, {}".format(current_object.label, previous_object.label, score.item(), dist)
+            )
+            # FIXME pick best match?
+            if self.is_match(score.item(), dist):
+                is_novel = False
+                current_object.eid = previous_object.eid
+        logging.info("world object {}, is_novel {}".format(current_object.label, is_novel))
+        return is_novel
+
+    def handle(self, current_objects, previous_objects):
+        """run the deduplication for the current objects detected.
+
+        This is also where each WorldObject is assigned a unique entity id (eid).
+
+        Args:
+            current_objects (list[WorldObject]): a list of all WorldObjects detected in the current frame
+            previous_objects (list[WorldObject]): a list of all previous WorldObjects ever detected
+        """
+        logging.info("In ObjectDeduplicationHandler ... ")
+        new_objects = []
+        updated_objects = []
+        for current_object in current_objects:
+            if self.is_novel(current_object, previous_objects):
+                current_object.eid = self.object_id_counter
+                self.object_id_counter = self.object_id_counter + 1
+                new_objects.append(current_object)
+
+                logging.info(
+                    f"Instance ({current_object.label}) is at location: "
+                    "({np.around(np.array(current_object.xyz), 2)}),"
+                    " Center:({current_object.center})"
+                )
+            else:
+                updated_objects.append(current_object)
+
+        return new_objects, updated_objects

--- a/locobot/agent/perception/handlers/memory.py
+++ b/locobot/agent/perception/handlers/memory.py
@@ -24,10 +24,6 @@ class MemoryHandler(AbstractHandler):
 
     def __init__(self, agent):
         self.agent = agent
-        self.object_id_counter = 1
-        self.dedupe_model = models.resnet18(pretrained=True).cuda()
-        self.layer = self.dedupe_model._modules.get("avgpool")
-        self.dedupe_model.eval()
         self.init_event_handlers()
 
     def init_event_handlers(self):
@@ -39,89 +35,21 @@ class MemoryHandler(AbstractHandler):
             self.agent.dashboard_memory["objects"] = objects
             sio.emit("updateState", {"memory": self.agent.dashboard_memory})
 
-    def get_feature_repr(self, img):
-        normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
-        to_tensor = transforms.ToTensor()
-        t_img = normalize(to_tensor(img)).unsqueeze(0).cuda()
-        my_embedding = torch.zeros(512)
+    def get_objects(self):
+        return loco_memory.DetectedObjectNode.get_all(self.agent.memory)
 
-        def copy_data(m, i, o):
-            my_embedding.copy_(torch.flatten(o).data)
-
-        h = self.layer.register_forward_hook(copy_data)
-        with torch.no_grad():
-            self.dedupe_model(t_img)
-        h.remove()
-        return my_embedding
-
-    # Not accounting for moving objects
-    def is_match(self, score, dist):
-        score_thresh = 0.95
-        dist_thresh = 0.6
-        if score > score_thresh and dist > dist_thresh:
-            return False  # Similar object, different places.
-        elif score > score_thresh and dist < dist_thresh:
-            return True  # same object, same place
-        else:
-            return False
-
-    def is_novel(self, rgb, world_obj, dedupe):
-        """this is long-term tracking (not in-frame). it does some feature
-        matching to figure out if we've seen this exact instance of object
-        before.
-
-        It uses the cosine similarity of conv features and (separately),
-        distance between two objects
-        """
-        # Treat all objects as novel if dedupe is turned off.
-        if not dedupe:
-            return True
-        world_obj.feature_repr = self.get_feature_repr(world_obj.get_masked_img())
-        cos = torch.nn.CosineSimilarity(dim=1)
-        is_novel = True
-        objects = loco_memory.DetectedObjectNode.get_all(self.agent.memory)
-        # Future = use all object features to calculate novelty
-        for x in objects:
-            score = cos(x["feature_repr"].unsqueeze(0), world_obj.feature_repr.unsqueeze(0))
-            dist = np.linalg.norm(np.asarray(world_obj.xyz[:2]) - np.asarray(x["xyz"][:2]))
-            logging.debug(
-                "Similarity {}.{} = {}, {}".format(world_obj.label, x["label"], score.item(), dist)
-            )
-            # FIXME pick best match?
-            if self.is_match(score.item(), dist):
-                is_novel = False
-                world_obj.eid = x["eid"]
-            # delete so that we can emit it (i.e. x becomes serializable as-is)
-            del x["feature_repr"]
-        # todo: only emit new or updated objects, rather than emitting everything everything
-        self.agent.dashboard_memory["objects"] = objects
-        sio.emit("updateState", {"memory": self.agent.dashboard_memory})
-        logging.info("world object {}, is_novel {}".format(world_obj.label, is_novel))
-        return is_novel
-
-    def handle(self, rgb, objects, dedupe=True):
+    def handle(self, new_objects, updated_objects):
         """run the memory handler for the current rgb, objects detected.
 
         This is also where each WorldObject is assigned a unique entity id (eid).
 
         Args:
-            rgb (np.array): current RGB image for which the handlers are being run
-            objects (list[WorldObject]): a list of all WorldObjects detected
-            dedupe (boolean): boolean to indicate whether to deduplicate objects or not. If False, all objects
-            are considered to be new/novel objects that the agent hasn't seen before. If True, the handler tries to
-            identify whether it has seen a WorldObject before and updates it if it has.
+            new_objects (list[WorldObject]): a list of new WorldObjects to be stored in memory
+            updated_objects (list[WorldObject]): a list of WorldObjects to be updated in memory
         """
         logging.info("In MemoryHandler ... ")
-        for i, x in enumerate(objects):
-            if self.is_novel(rgb, x, dedupe):
-                x.eid = self.object_id_counter
-                self.object_id_counter = self.object_id_counter + 1
-                x.save_to_memory(self.agent)
-                logging.info(
-                    f"Instance#{i} ({x.label}) is at location: ({np.around(np.array(x.xyz), 2)}), Center:({x.center})"
-                )
-            else:
-                x.save_to_memory(self.agent, update=True)
-        logging.debug(
-            f"Current Locobot pos (x_standard, z_standard, yaw) is: {self.agent.mover.get_base_pos_in_canonical_coords()}"
-        )
+
+        for obj in new_objects:
+            obj.save_to_memory(self.agent)
+        for obj in updated_objects:
+            obj.save_to_memory(self.agent, update=True)

--- a/locobot/agent/perception/perception.py
+++ b/locobot/agent/perception/perception.py
@@ -9,6 +9,7 @@ from .handlers import (
     TrackingHandler,
     MemoryHandler,
     LaserPointerHandler,
+    ObjectDeduplicationHandler,
 )
 import time
 from objects import AttributeDict
@@ -65,7 +66,7 @@ class SlowPerception:
         # laser_detection_obj = self.vision.laser_pointer(rgb_depth)
         # if laser_detection_obj:
         #     detections += [laser_detection_obj]
-        self.vision.tracker(rgb_depth, detections)
+        # self.vision.tracker(rgb_depth, detections)
         return rgb_depth, detections, humans
 
 
@@ -158,6 +159,7 @@ class Perception:
         handlers = AttributeDict(
             {
                 "input": InputHandler(self.agent, read_from_camera=True),
+                "deduplicate": ObjectDeduplicationHandler(),
                 "memory": MemoryHandler(self.agent),
             }
         )
@@ -191,7 +193,11 @@ class Perception:
             raise ChildProcessError(_traceback)
 
         if detections is not None:
-            self.vision.memory(old_image.rgb, detections + humans)
+            previous_objects = self.vision.memory.get_objects()
+            current_objects = detections + humans
+            if previous_objects is not None:
+                new_objects, updated_objects = self.vision.deduplicate(current_objects, previous_objects)
+            self.vision.memory(new_objects, updated_objects)
 
         self.log(rgb_depth, detections, humans, old_image, old_xyz)
 


### PR DESCRIPTION
This makes object deduplcation purely functional, and easier to both test and reason about.

The MemoryHandler still handles all memory back-and-forth in the perception pipeline, so there's no change in that scope

Do not merge this PR. Once the stack is approved, merge https://github.com/facebookresearch/droidlet/pull/133 instead.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #132 Add a Locobot + Habitat based tutorial
* #131 bug fixes in path handling
* #130 small refactor of DetectedObjectNode
* #129 carve out the dialog model into it's own little self-contained class
* **#128 refactor locobot perception MemoryHandler, carve out Object deduplication into it's own handler**
* #127 better variable naming
* #126 add silent mode to TrackingHandler
* #125 allow move_relative and move_absolute to also take single xyt, not just lists of xyt
* #124 remove incorrect gitiginore
* #123 [dashboard] new binary build
* #122 [dashboard frontend] add more atomic events in dashboard and fix some bugs found in the process
* #121 fix a race condition in dashboard backend startup

