### PR TITLE
Remove empty chat print from agent processes

### DIFF
--- a/base_agent/loco_mc_agent.py
+++ b/base_agent/loco_mc_agent.py
@@ -249,7 +249,8 @@ class LocoMCAgent(BaseAgent):
     def controller_step(self):
         """Process incoming chats and modify task stack"""
         raw_incoming_chats = self.get_incoming_chats()
-        logging.info("Incoming chats: {}".format(raw_incoming_chats))
+        if raw_incoming_chats:
+            logging.info("Incoming chats: {}".format(raw_incoming_chats))
         incoming_chats = []
         for raw_chat in raw_incoming_chats:
             match = re.search("^<([^>]+)> (.*)", raw_chat)


### PR DESCRIPTION
# Description

This PR only prints the `Incoming chats` only if there are any commands coming in. Previously it would flood the log file with empty chats.

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.
