### PR TITLE
Updated versioned docker container tagging method

### DIFF
--- a/craftassist/servermgr/README.md
+++ b/craftassist/servermgr/README.md
@@ -29,7 +29,7 @@
 1. Verify that the commit passed CI successfully. If all is green, you should see under the "Push versioned docker containers" step a line like
 
 ```
-docker push ECR_image_URI:tag
+<Commit SHA1>: digest: <DIGEST>: size: xxxx
 ```
 
 Notice that tag is the SHA1 of the latest master commit
@@ -37,10 +37,10 @@ Notice that tag is the SHA1 of the latest master commit
 2. Run [tools/docker/promote.sh](https://github.com/facebookresearch/droidlet/blob/main/tools/docker/promote.sh) using the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY credentials like this:
 
 ```
-AWS_ACCESS_KEY_ID="key id here" AWS_SECRET_ACCESS_KEY="secret access key here" ./tools/docker/promote.sh <tag from above>
+AWS_ACCESS_KEY_ID="key id here" AWS_SECRET_ACCESS_KEY="secret access key here" ./tools/docker/promote.sh <DIGEST from above>
 ```
 
-Replacing the <tag from above> with whatever commit you'd like to promote
+Replacing the <DIGEST from above> with whatever digest you'd like to promote
 
 
 ## How to deploy a new servermgr

--- a/tools/docker/promote.sh
+++ b/tools/docker/promote.sh
@@ -15,8 +15,8 @@ fi
 MANIFEST=$(aws ecr batch-get-image \
     --repository-name craftassist \
     --region us-west-1 \
-    --image-ids imageTag=$IMAGE_TAG \
-    --query images[].imageManifest \
+    --image-ids imageDigest=$IMAGE_TAG \
+    --query "images[].imageManifest" \
     --output text)
 
 echo $MANIFEST


### PR DESCRIPTION
# Description

Previously only versioned docker image on main branch can be tagged as latest. Now changing to use image digest instead of image tag in promote script to search for images in aws ecr. This allows docker image on other feature branch to be tagged as latest so that servermgr can use it.


## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

# Testing

Tested locally.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

