### PR TITLE
remove trailing spaces from templated blockly tool

### DIFF
--- a/tools/annotation_tools/template_tool/backend/pythonGenerator/generators.py
+++ b/tools/annotation_tools/template_tool/backend/pythonGenerator/generators.py
@@ -135,6 +135,7 @@ def generate_template(info):
         info["code"] = {}
     dictionary = {}
     dictionary = generate_dictionary(info["code"])
+    surface_form = surface_form.strip()
     return [surface_form, dictionary]
 
 


### PR DESCRIPTION
# Description

This PR fixes the extra trailing spaces at the end of every command in the templated_filters data source

Fixes #187 

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before: "have you seen my pull-up bars "

After: "have you seen my pull-up bars"

# Testing

Tested the change locally by stripping and comparing.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

