### PR TITLE
Attenuate fixed value loss and adjust weight in training jobs 

### DIFF
--- a/base_agent/ttad/ttad_transformer_model/train_model.py
+++ b/base_agent/ttad/ttad_transformer_model/train_model.py
@@ -299,6 +299,8 @@ def generate_model_name(args, optional_identifier=""):
         "param_update_freq": "upd_frq",
         "word_dropout": "word_drp",
         "alpha": "a",
+        "train_encoder": "tr",
+        "fixed_value_weight": "fv"
     }
     for k, v in vars(args).items():
         if k in args_keys:
@@ -365,7 +367,7 @@ def main():
         "--examples_per_epoch", default=-1, type=int, help="Number of training examples per epoch"
     )
     parser.add_argument(
-        "--train_encoder", action="store_true", help="Whether to finetune the encoder"
+        "--train_encoder", default=True, type=bool, help="Whether to finetune the encoder"
     )
     parser.add_argument(
         "--encoder_warmup_steps",
@@ -427,8 +429,8 @@ def main():
     )
     parser.add_argument(
         "--hard",
-        default=False,
-        action="store_true",
+        default=True,
+        type=bool,
         help="Whether to feed in failed examples during training"
     )
     parser.add_argument(
@@ -439,7 +441,7 @@ def main():
     )
     parser.add_argument(
         "--fixed_value_weight",
-        default=0.8,
+        default=0.1,
         type=float,
         help="Attenuation factor for fixed value loss gradient affecting shared layers for tree structure prediction",
     )

--- a/base_agent/ttad/ttad_transformer_model/utils_parsing.py
+++ b/base_agent/ttad/ttad_transformer_model/utils_parsing.py
@@ -198,8 +198,11 @@ class DecoderWithLoss(nn.Module):
             lm_lin_mask = y_mask_target.view(-1)
             lm_loss = lm_lin_loss.sum() / lm_lin_mask.sum()
             # fixed span value output head
-            fixed_span_hidden_states = y_rep
-            fixed_span_scores = self.fixed_span_head(fixed_span_hidden_states)
+            self.fixed_span_hidden_z = y_rep.detach()
+            self.fixed_span_hidden_z.requires_grad = True
+            self.fixed_span_hidden_z.retain_grad()
+            # fixed_span_hidden_states = y_rep
+            fixed_span_scores = self.fixed_span_head(self.fixed_span_hidden_z)
             fixed_span_lin_scores = fixed_span_scores.view(-1, fixed_span_scores.shape[-1])
             fixed_span_lin_targets = y[:, 1:, 5].contiguous().view(-1)
             fixed_span_lin_loss = self.fixed_span_loss(fixed_span_lin_scores, fixed_span_lin_targets)
@@ -232,7 +235,7 @@ class DecoderWithLoss(nn.Module):
             # combine
             span_lin_loss = span_b_lin_loss + span_e_lin_loss
             span_loss = span_lin_loss.sum() / (y[:, :, 1] >= 0).sum()
-            tot_loss = (1 - self.span_loss_lb) * lm_loss + self.span_loss_lb * span_loss + 0.05 * fixed_span_loss
+            tot_loss = (1 - self.span_loss_lb) * lm_loss + self.span_loss_lb * span_loss
             # text span prediction
             # detach head
             if not is_eval:

--- a/base_agent/ttad/ttad_transformer_model/utils_parsing.py
+++ b/base_agent/ttad/ttad_transformer_model/utils_parsing.py
@@ -201,7 +201,6 @@ class DecoderWithLoss(nn.Module):
             self.fixed_span_hidden_z = y_rep.detach()
             self.fixed_span_hidden_z.requires_grad = True
             self.fixed_span_hidden_z.retain_grad()
-            # fixed_span_hidden_states = y_rep
             fixed_span_scores = self.fixed_span_head(self.fixed_span_hidden_z)
             fixed_span_lin_scores = fixed_span_scores.view(-1, fixed_span_scores.shape[-1])
             fixed_span_lin_targets = y[:, 1:, 5].contiguous().view(-1)


### PR DESCRIPTION
# Description

This PR sets up gradient attenuation for fixed value loss:
- Separate Adam optimizer for fixed value head
- Remove fixed value loss from combined loss in backprop; apply gradient updates manually for shared decoder layers
- Configure fixed value loss attenuation factor from command line
- Save fixed value configs in model name generation (used to organize saved models)

Also changed some param types to store bool values for more convenient sweeps.

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

# Testing

Loss converges during some test training runs.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

