### PR TITLE
Generate configs for sweeps using grid search

### DIFF
--- a/base_agent/ttad/ttad_transformer_model/train_model.py
+++ b/base_agent/ttad/ttad_transformer_model/train_model.py
@@ -299,6 +299,8 @@ def generate_model_name(args, optional_identifier=""):
         "param_update_freq": "upd_frq",
         "word_dropout": "word_drp",
         "alpha": "a",
+        "train_encoder": "tr",
+        "fixed_value_weight": "fv"
     }
     for k, v in vars(args).items():
         if k in args_keys:
@@ -365,7 +367,7 @@ def main():
         "--examples_per_epoch", default=-1, type=int, help="Number of training examples per epoch"
     )
     parser.add_argument(
-        "--train_encoder", action="store_true", help="Whether to finetune the encoder"
+        "--train_encoder", default=True, type=bool, help="Whether to finetune the encoder"
     )
     parser.add_argument(
         "--encoder_warmup_steps",
@@ -427,8 +429,8 @@ def main():
     )
     parser.add_argument(
         "--hard",
-        default=False,
-        action="store_true",
+        default=True,
+        type=bool,
         help="Whether to feed in failed examples during training"
     )
     parser.add_argument(
@@ -439,7 +441,7 @@ def main():
     )
     parser.add_argument(
         "--fixed_value_weight",
-        default=0.8,
+        default=0.1,
         type=float,
         help="Attenuation factor for fixed value loss gradient affecting shared layers for tree structure prediction",
     )

--- a/base_agent/ttad/ttad_transformer_model/utils_parsing.py
+++ b/base_agent/ttad/ttad_transformer_model/utils_parsing.py
@@ -198,8 +198,11 @@ class DecoderWithLoss(nn.Module):
             lm_lin_mask = y_mask_target.view(-1)
             lm_loss = lm_lin_loss.sum() / lm_lin_mask.sum()
             # fixed span value output head
-            fixed_span_hidden_states = y_rep
-            fixed_span_scores = self.fixed_span_head(fixed_span_hidden_states)
+            self.fixed_span_hidden_z = y_rep.detach()
+            self.fixed_span_hidden_z.requires_grad = True
+            self.fixed_span_hidden_z.retain_grad()
+            # fixed_span_hidden_states = y_rep
+            fixed_span_scores = self.fixed_span_head(self.fixed_span_hidden_z)
             fixed_span_lin_scores = fixed_span_scores.view(-1, fixed_span_scores.shape[-1])
             fixed_span_lin_targets = y[:, 1:, 5].contiguous().view(-1)
             fixed_span_lin_loss = self.fixed_span_loss(fixed_span_lin_scores, fixed_span_lin_targets)
@@ -232,7 +235,7 @@ class DecoderWithLoss(nn.Module):
             # combine
             span_lin_loss = span_b_lin_loss + span_e_lin_loss
             span_loss = span_lin_loss.sum() / (y[:, :, 1] >= 0).sum()
-            tot_loss = (1 - self.span_loss_lb) * lm_loss + self.span_loss_lb * span_loss + 0.05 * fixed_span_loss
+            tot_loss = (1 - self.span_loss_lb) * lm_loss + self.span_loss_lb * span_loss
             # text span prediction
             # detach head
             if not is_eval:

--- a/base_agent/ttad/ttad_transformer_model/utils_parsing.py
+++ b/base_agent/ttad/ttad_transformer_model/utils_parsing.py
@@ -201,7 +201,6 @@ class DecoderWithLoss(nn.Module):
             self.fixed_span_hidden_z = y_rep.detach()
             self.fixed_span_hidden_z.requires_grad = True
             self.fixed_span_hidden_z.retain_grad()
-            # fixed_span_hidden_states = y_rep
             fixed_span_scores = self.fixed_span_head(self.fixed_span_hidden_z)
             fixed_span_lin_scores = fixed_span_scores.view(-1, fixed_span_scores.shape[-1])
             fixed_span_lin_targets = y[:, 1:, 5].contiguous().view(-1)

--- a/tools/nsp_scripts/generate_configs_for_sweeps.py
+++ b/tools/nsp_scripts/generate_configs_for_sweeps.py
@@ -1,0 +1,69 @@
+"""
+This script reads in a .txt file containing the grid search sweep config ranges,
+and generates config files to be used in slurm jobs.
+"""
+import argparse
+import os
+
+def generate_config_pair(arr1, arr2):
+    configs = []
+    for x in arr1:
+        for y in arr2:
+            if type(x) == list:
+                configs.append([*x, y])
+            else:
+                configs.append([x, y])
+    return configs
+
+
+def generate_configs_from_file(input_file):
+    with open(input_file, "r") as fd:
+        params = fd.read().splitlines()
+
+    full_args = []
+    for line in params:
+        arg, values_range = line.split("=")
+        values = values_range.split(":")
+        arr1 = ["{}={}".format(arg, v) for v in values]
+        full_args.append(arr1)
+
+    configs = generate_config_pair(full_args[0], full_args[1])
+    for i in range(2, len(full_args)):
+        new_configs = generate_config_pair(configs, full_args[i])
+        configs = new_configs
+
+    print(configs)
+    print(len(configs))
+    return configs
+
+def write_config_to_file(config, idx, output_dir, sweep_output_dir, data_dir):
+    output_path = "{}config_{}.txt".format(output_dir, idx)
+    with open(output_path, "w") as fd:
+        for c in config:
+            fd.write("--" + c + "\n")
+        # additional for static
+        fd.write("--output_dir={}/sweep{}/\n".format(sweep_output_dir, idx))
+        fd.write("--data_dir={}\n".format(data_dir))
+        fd.write("--tree_voc_file={}/caip_test_model_tree.json\n".format(sweep_output_dir))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    # Path to sweep config, i.e. which parameters to run and their ranges for grid search
+    parser.add_argument("--sweep_params_path", help="path to sweep params and values to search over")
+    # Name of sweep, to identify
+    parser.add_argument("--data_dir", help="path to training data directory containing train/test/valid split")
+    parser.add_argument("--output_dir", help="where to write configs to")
+    parser.add_argument("--sweep_output_dir", help="where to save models to during sweeps")
+
+    opts = parser.parse_args()
+    input_file = opts.sweep_params_path
+    configs = generate_configs_from_file(input_file)
+    output_dir = opts.output_dir
+    sweep_output_dir = opts.sweep_output_dir
+    for i in range(len(configs)):
+        write_config_to_file(configs[i], i, output_dir, sweep_output_dir, data_dir)
+        # create sweep directories
+        sweep_dir_path = "{}sweep{}/".format(sweep_output_dir, i)
+        if not os.path.isdir(sweep_dir_path):
+            os.mkdir(sweep_dir_path)


### PR DESCRIPTION
# Description

Checking in grid search script to generate configs with different param combinations. 

Previously, we submitted N sbatch jobs for a sweep containing N jobs. Since we are using SLURM arrays now for better cluster usage, we only submit 1 sbatch job for each sweep containing N runs. So it's necessary that we generate and read from N config files instead of write configs to N sbatch scripts.

Fixes # (issue)
#208 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Script takes in path to .txt config params as input and outputs `config<ID>.txt` for each param combination to the provided output directory. Also creates `sweep<ID>` directory for each training run, where binarized models and vocab files are saved.

# Testing

Successfully submitted SLURM jobs with configs generated from this script.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

