### PR TITLE
Added instructions to set up required env var to README

### DIFF
--- a/crowdsourcing/README.md
+++ b/crowdsourcing/README.md
@@ -11,3 +11,17 @@ python droidlet_static_html_task/static_test_script.py mephisto.architect.server
 ```
 
 You can replace `droidlet_static_html_task/static_test_script.py` with any mephisto task you would like to run and replace `./servermgr` with any heroku server setup you would like to use.
+
+## Extra configs for using servermgr
+
+Since we are requesting ECS instance in servermgr flask app. It's required to set up aws-specific information as environment variable passed to heroku. Add the following entries to your mephisto config file:
+
+```
+mephisto:
+  architect:
+    heroku_app_name: YOUR_HEROKU_APP_NAME
+    heroku_config_args:
+      AWS_ACCESS_KEY_ID: XXX
+      AWS_SECRET_ACCESS_KEY: XXX
+      AWS_DEFAULT_REGION: XXX (should be "us-west-1")
+```


### PR DESCRIPTION
# Description

In order to use heroku architect in mephisto. It's required to set up a few aws-specific environment variables so that it can be passed to heroku app during building.

Note that it only applied to our servermgr flask app because we are requesting ecs instances in this app. For other mephisto apps it's not required.


## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [x] Documentation only change

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

