### PR TITLE
Fix task filters

### DIFF
--- a/base_agent/dialogue_objects/filter_helper.py
+++ b/base_agent/dialogue_objects/filter_helper.py
@@ -145,9 +145,11 @@ def maybe_apply_selector(interpreter, speaker, filters_d, F):
 def interpret_task_filter(interpreter, speaker, filters_d, get_all=False):
     F = MemoryFilter(interpreter.agent.memory)
 
+    task_tags = ["currently_running", "running", "paused", "finished"]
+
     T = filters_d.get("triples")
     task_properties = [
-        a.get("obj_text")[1:].lower() for a in T if a.get("obj_text", "").startswith("_")
+        a.get("obj_text")[1:].lower() for a in T if a.get("obj_text", "").lower() in task_tags
     ]
     search_data = {}
     search_data["base_table"] = "Tasks"

--- a/base_agent/dialogue_objects/filter_helper.py
+++ b/base_agent/dialogue_objects/filter_helper.py
@@ -149,7 +149,7 @@ def interpret_task_filter(interpreter, speaker, filters_d, get_all=False):
 
     T = filters_d.get("triples")
     task_properties = [
-        a.get("obj_text")[1:].lower() for a in T if a.get("obj_text", "").lower() in task_tags
+        a.get("obj_text").lower() for a in T if a.get("obj_text", "").lower() in task_tags
     ]
     search_data = {}
     search_data["base_table"] = "Tasks"

--- a/craftassist/test/test_get_memory.py
+++ b/craftassist/test/test_get_memory.py
@@ -51,6 +51,9 @@ class GetMemoryTestCase(BaseCraftassistTestCase):
         self.assertIn("SPEAKER", self.last_outgoing_chat())
 
     def test_what_are_you_doing(self):
+        d = DANCE_COMMANDS["dance"]
+        self.handle_logical_form(d)
+
         # start building a cube
         d = BUILD_COMMANDS["build a small cube"]
         self.handle_logical_form(d, max_steps=9)
@@ -61,6 +64,7 @@ class GetMemoryTestCase(BaseCraftassistTestCase):
 
         # check that proper chat was sent
         self.assertIn("build", self.last_outgoing_chat())
+        assert not "dance" in self.last_outgoing_chat()
 
     def test_what_are_you_building(self):
         # start building a cube


### PR DESCRIPTION
# Description

After the change to fixed_value keys the handler for task filters was not properly updated, this fixes it and extends a test.

Fixes # (issue)
https://github.com/facebookresearch/droidlet/issues/238

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After
Before:  searches on filters that should e.g. only return running tasks would return all
After: fixed

# Testing

updated get_memory tests to make sure only current task is being returned when bot is asked

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [x] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

