### PR TITLE
move height and width to base agent, allow 'size' queries

### DIFF
--- a/base_agent/dialogue_objects/attribute_helper.py
+++ b/base_agent/dialogue_objects/attribute_helper.py
@@ -8,6 +8,7 @@ from memory_attributes import (
     ListAttribute,
     TripleWalk,
     AttributeSequence,
+    BBoxSize,
 )
 from memory_values import LinearExtentValue, FixedValue, convert_comparison_value
 from base_util import ErrorWithResponse, number_from_span
@@ -167,6 +168,13 @@ def interpret_task_info(interpreter, speaker, d):
 class AttributeInterpreter:
     def __call__(self, interpreter, speaker, d_attribute, get_all=False):
         if type(d_attribute) is str:
+            if (
+                d_attribute.lower() == "height"
+                or d_attribute.lower() == "width"
+                or d_attribute.lower() == "height"
+                or d_attribute.lower() == "size"
+            ):
+                return BBoxSize(interpreter.agent, d_attribute.lower())
             d_attribute = CANONICALIZE_ATTRIBUTES.get(d_attribute.lower())
             if d_attribute and type(d_attribute) is str:
                 return TableColumn(interpreter.agent, d_attribute, get_all=get_all)

--- a/base_agent/test/all_test_commands.py
+++ b/base_agent/test/all_test_commands.py
@@ -692,6 +692,16 @@ GET_MEMORY_COMMANDS = {
             "output": {"attribute": "HEIGHT"},
         },
     },
+    "how wide is the red cube?": {
+        "dialogue_type": "GET_MEMORY",
+        "filters": {
+            "triples": [
+                {"pred_text": "has_colour", "obj_text": "red"},
+                {"pred_text": "has_name", "obj_text": "cube"},
+            ],
+            "output": {"attribute": "HEIGHT"},
+        },
+    },
     "how many cubes are there?": {
         "dialogue_type": "GET_MEMORY",
         "filters": {

--- a/base_agent/test/all_test_commands.py
+++ b/base_agent/test/all_test_commands.py
@@ -682,6 +682,16 @@ GET_MEMORY_COMMANDS = {
             },
         },
     },
+    "how tall is the blue cube?": {
+        "dialogue_type": "GET_MEMORY",
+        "filters": {
+            "triples": [
+                {"pred_text": "has_colour", "obj_text": "blue"},
+                {"pred_text": "has_name", "obj_text": "cube"},
+            ],
+            "output": {"attribute": "HEIGHT"},
+        },
+    },
     "how many cubes are there?": {
         "dialogue_type": "GET_MEMORY",
         "filters": {
@@ -1063,25 +1073,25 @@ GROUND_TRUTH_PARSES = {
     },
     "turn right 90 degrees": {
         "action_sequence": [
-            {"action_type": "DANCE", "dance_type": {"body_turn": {"relative_yaw": "-90"}},}
+            {"action_type": "DANCE", "dance_type": {"body_turn": {"relative_yaw": "-90"}}}
         ],
         "dialogue_type": "HUMAN_GIVE_COMMAND",
     },
     "turn left 90 degrees": {
         "action_sequence": [
-            {"action_type": "DANCE", "dance_type": {"body_turn": {"relative_yaw": "90"}},}
+            {"action_type": "DANCE", "dance_type": {"body_turn": {"relative_yaw": "90"}}}
         ],
         "dialogue_type": "HUMAN_GIVE_COMMAND",
     },
     "turn right 180 degrees": {
         "action_sequence": [
-            {"action_type": "DANCE", "dance_type": {"body_turn": {"relative_yaw": "-180"}},}
+            {"action_type": "DANCE", "dance_type": {"body_turn": {"relative_yaw": "-180"}}}
         ],
         "dialogue_type": "HUMAN_GIVE_COMMAND",
     },
     "turn right": {
         "action_sequence": [
-            {"action_type": "DANCE", "dance_type": {"body_turn": {"relative_yaw": "-90"}},}
+            {"action_type": "DANCE", "dance_type": {"body_turn": {"relative_yaw": "-90"}}}
         ],
         "dialogue_type": "HUMAN_GIVE_COMMAND",
     },

--- a/base_agent/test/all_test_commands.py
+++ b/base_agent/test/all_test_commands.py
@@ -699,7 +699,7 @@ GET_MEMORY_COMMANDS = {
                 {"pred_text": "has_colour", "obj_text": "red"},
                 {"pred_text": "has_name", "obj_text": "cube"},
             ],
-            "output": {"attribute": "HEIGHT"},
+            "output": {"attribute": "WIDTH"},
         },
     },
     "how many cubes are there?": {

--- a/craftassist/agent/dialogue_objects/attribute_helper.py
+++ b/craftassist/agent/dialogue_objects/attribute_helper.py
@@ -2,16 +2,13 @@
 Copyright (c) Facebook, Inc. and its affiliates.
 """
 from base_agent.dialogue_objects import AttributeInterpreter
-from mc_attributes import VoxelGeometry, VoxelCounter
+from mc_attributes import VoxelCounter
 
-# this will become unnecessary with distance between
+
 class MCAttributeInterpreter(AttributeInterpreter):
     def __call__(self, interpreter, speaker, d_attribute, get_all=False):
         if type(d_attribute) is str:
-            if d_attribute.lower() == "height" or d_attribute.lower() == "width":
-                return VoxelGeometry(interpreter.agent, d_attribute.lower())
-            else:
-                return super().__call__(interpreter, speaker, d_attribute, get_all=get_all)
+            return super().__call__(interpreter, speaker, d_attribute, get_all=get_all)
         elif type(d_attribute) is dict:
             bd = d_attribute.get("num_blocks")
             if bd:

--- a/craftassist/agent/mc_attributes.py
+++ b/craftassist/agent/mc_attributes.py
@@ -3,24 +3,6 @@ Copyright (c) Facebook, Inc. and its affiliates.
 """
 from base_agent.memory_attributes import Attribute
 
-
-class VoxelGeometry(Attribute):
-    def __init__(self, agent, attribute="height"):
-        """height, max_width"""
-        super().__init__(agent)
-        self.attribute = attribute
-
-    def __call__(self, mems):
-        bounds = [m.get_bounds() for m in mems]
-        if self.attribute == "width":
-            return [max(b[1] - b[0] + 1, b[5] - b[4] + 1) for b in bounds]
-        else:
-            return [b[3] - b[2] + 1 for b in bounds]
-
-    def __repr__(self):
-        return "VoxelGeometry " + str(self.attribute)
-
-
 # TODO sqlize these?
 # FIXME!!!!! rn this will not accurately count voxels in
 # InstSeg objects with given properties;

--- a/craftassist/test/test_get_memory.py
+++ b/craftassist/test/test_get_memory.py
@@ -112,7 +112,7 @@ class GetMemoryCountAndSizeTest(BaseCraftassistTestCase):
         red_sphere_triples = {"has_name": "sphere", "has_shape": "sphere", "has_colour": "red"}
         blue_sphere_triples = {"has_name": "sphere", "has_shape": "sphere", "has_colour": "blue"}
         self.cube1 = self.add_object(
-            shapes.cube(bid=(35, 14)), (19, 63, 14), relations=red_cube_triples
+            shapes.cube(size=2, bid=(35, 14)), (19, 63, 14), relations=red_cube_triples
         )
         self.cube2 = self.add_object(
             shapes.cube(size=2, bid=(35, 14)), (15, 63, 15), relations=red_cube_triples

--- a/craftassist/test/test_get_memory.py
+++ b/craftassist/test/test_get_memory.py
@@ -104,7 +104,7 @@ class GetMemoryTestCase(BaseCraftassistTestCase):
         assert loc_in_chat
 
 
-class GetMemoryCountTest(BaseCraftassistTestCase):
+class GetMemoryCountAndSizeTest(BaseCraftassistTestCase):
     def setUp(self):
         super().setUp()
         red_cube_triples = {"has_name": "cube", "has_shape": "cube", "has_colour": "red"}
@@ -118,7 +118,7 @@ class GetMemoryCountTest(BaseCraftassistTestCase):
             shapes.cube(bid=(35, 14)), (15, 63, 15), relations=red_cube_triples
         )
         self.cube3 = self.add_object(
-            shapes.cube(bid=(35, 11)), (14, 63, 19), relations=blue_cube_triples
+            shapes.cube(size=3, bid=(35, 11)), (14, 63, 19), relations=blue_cube_triples
         )
         self.sphere1 = self.add_object(
             shapes.sphere(bid=(35, 14), radius=2), (14, 63, 8), relations=red_sphere_triples
@@ -128,7 +128,7 @@ class GetMemoryCountTest(BaseCraftassistTestCase):
         )
         self.set_looking_at(list(self.cube1.blocks.keys())[0])
 
-    def test_get_name_and_left_of(self):
+    def test_counts_and_size(self):
         d = GET_MEMORY_COMMANDS["how many cubes are there?"]
         self.handle_logical_form(d, stop_on_chat=True)
 
@@ -147,6 +147,12 @@ class GetMemoryCountTest(BaseCraftassistTestCase):
 
         # check that proper chat was sent
         self.assertIn("27", self.last_outgoing_chat())
+
+        d = GET_MEMORY_COMMANDS["how tall is the blue cube?"]
+        self.handle_logical_form(d, stop_on_chat=True)
+
+        # check that proper chat was sent
+        self.assertIn("3", self.last_outgoing_chat())
 
 
 if __name__ == "__main__":

--- a/craftassist/test/test_get_memory.py
+++ b/craftassist/test/test_get_memory.py
@@ -115,7 +115,7 @@ class GetMemoryCountAndSizeTest(BaseCraftassistTestCase):
             shapes.cube(bid=(35, 14)), (19, 63, 14), relations=red_cube_triples
         )
         self.cube2 = self.add_object(
-            shapes.cube(bid=(35, 14)), (15, 63, 15), relations=red_cube_triples
+            shapes.cube(size=2, bid=(35, 14)), (15, 63, 15), relations=red_cube_triples
         )
         self.cube3 = self.add_object(
             shapes.cube(size=3, bid=(35, 11)), (14, 63, 19), relations=blue_cube_triples
@@ -153,6 +153,12 @@ class GetMemoryCountAndSizeTest(BaseCraftassistTestCase):
 
         # check that proper chat was sent
         self.assertIn("3", self.last_outgoing_chat())
+
+        d = GET_MEMORY_COMMANDS["how wide is the red cube?"]
+        self.handle_logical_form(d, stop_on_chat=True)
+
+        # check that proper chat was sent
+        self.assertIn("2", self.last_outgoing_chat())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
move height and width to base agent from craftassist (via bounding boxes), allow 'size' queries, add a test for "height" attribute
## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

previously height/width were only available in craftassist, and there was no generic "size" attribute.  height and width are implemented in base_agent via bounding boxes. generic size returns a (w, h, w) tuple where the order of the two w's is not defined

# Testing

added a "what is the height of the cube" test to test_get_memory

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [x] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

