### PR TITLE
Load IP dynamically on Mephisto task creation

### DIFF
--- a/crowdsourcing/README.md
+++ b/crowdsourcing/README.md
@@ -18,13 +18,27 @@ This opens up a task in your browser on localhost, and allows you to view your t
 ## Running Static HTML Tasks with Heroku
 
 ### Pre-reqs
-You need to have a Heroku account and valid Heroku credentials. To install Heroku CLI on Mac OSX, run `brew tap heroku/brew && brew install heroku`. Then log in with `heroku login`.
+You need to have a Heroku account and valid Heroku credentials. To install Heroku CLI on Mac OSX, run `brew tap heroku/brew && brew install heroku`. Then log in with `heroku login` (pass the `-i` flag for validation without browser).
 
 For other installation methods, see https://devcenter.heroku.com/articles/heroku-cli.
 
 You also need an AWS IAM account with MTurk permissions. You also need AWS access keys with permissions to spin up ECS containers, which will be used to communicate with AWS in the flask app. These may or may not be the same access keys; contact your AWS system administrator if you do not have these credentials. 
 
 During the Mephisto onboarding tutorial, you would've configured Mephisto with your AWS credentials. Our Heroku architect pipeline also accesses environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`; ensure that these are set.
+
+### Configuring Job Parameters
+To configure job parameters, create a file `data.csv` in `droidlet_static_html_task/data.csv`. The header row contains the names of variables, and each row specifies parameters for a single Turk job.
+
+In the Droidlet static task, each turker is given a unique instance of the Voxel world. Currently we pre-launch ECS instances, and set up HTTP/HTTPS proxies for each instance via Cloudflare. Each row in `data.csv` specifies a unique IP. The format of `data.csv` is as follows:
+
+```
+subdomain
+<IP1>
+<IP2>
+...
+```
+
+We can access these template variables directly in the HTML tasks.
 
 ### Running tasks
 Run the following command to start a `droidlet_static_html_task` with `heroku` architect and `flask` server type

--- a/crowdsourcing/droidlet_static_html_task/server_files/craftassist_task.html
+++ b/crowdsourcing/droidlet_static_html_task/server_files/craftassist_task.html
@@ -97,7 +97,7 @@
     height: 1000px;
   "
 >
-<iframe style="width:100%; height:100%;" src="https://craftassist.io/"></iframe>
+<iframe style="width:100%; height:100%;" src="https://${subdomain}.craftassist.io/"></iframe>
 </section>
 
 

--- a/crowdsourcing/droidlet_static_html_task/server_files/craftassist_task_preview.html
+++ b/crowdsourcing/droidlet_static_html_task/server_files/craftassist_task_preview.html
@@ -95,7 +95,7 @@
     height: 1000px;
   "
 >
-<iframe style="width:100%; height:100%;" src="https://craftassist.io/"></iframe>
+<iframe style="width:100%; height:100%;" src="https://${subdomain}.craftassist.io/"></iframe>
 </section>
 
 

--- a/crowdsourcing/servermgr/app.py
+++ b/crowdsourcing/servermgr/app.py
@@ -41,7 +41,7 @@ AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
 AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]
 AWS_DEFAULT_REGION = os.environ["AWS_DEFAULT_REGION"]
 
-port = int(os.environ.get("PORT", 3000))
+port = int(os.environ.get("PORT", 80))
 
 app = Flask(__name__)
 app.register_blueprint(mephisto_router, url_prefix=r"/")

--- a/crowdsourcing/servermgr/app.py
+++ b/crowdsourcing/servermgr/app.py
@@ -41,7 +41,7 @@ AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
 AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]
 AWS_DEFAULT_REGION = os.environ["AWS_DEFAULT_REGION"]
 
-port = int(os.environ.get("PORT", 80))
+port = int(os.environ.get("PORT", 3000))
 
 app = Flask(__name__)
 app.register_blueprint(mephisto_router, url_prefix=r"/")


### PR DESCRIPTION
# Description

Changes in this PR
- Set default port to 80, to allow us to use Cloudflare proxies
- Document how to set up `data.csv` for Turk job creation
- Load dashboard IPs dynamically from `data.csv` variables

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Using Mephisto's heroku architect:
![Screen Shot 2021-03-19 at 12 15 12 PM](https://user-images.githubusercontent.com/19957918/111851922-61305800-88d2-11eb-9275-335618e8f9a9.png)


# Testing

To run Mephisto pipeline locally on devfair:

```
python droidlet_static_html_task/static_test_script.py
```

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

