### PR TITLE
Remove port number from browser redirect

### DIFF
--- a/craftassist/servermgr/templates/wait.html
+++ b/craftassist/servermgr/templates/wait.html
@@ -59,7 +59,7 @@ $(document).ready(function() {
                 if (r.progress == 100) {
                     clearInterval(interval);
                     instance_ip_address = r.ip;
-                    window.location.replace("http://" + instance_ip_address + ":8000");
+                    window.location.replace("http://" + instance_ip_address);
                 }
             }).fail(function(err) {
                 console.error(err)

--- a/crowdsourcing/servermgr/templates/wait.html
+++ b/crowdsourcing/servermgr/templates/wait.html
@@ -59,7 +59,7 @@ $(document).ready(function() {
                 if (r.progress == 100) {
                     clearInterval(interval);
                     instance_ip_address = r.ip;
-                    window.location.replace("http://" + instance_ip_address + ":8000");
+                    window.location.replace("http://" + instance_ip_address);
                 }
             }).fail(function(err) {
                 console.error(err)

--- a/dldashboard/__init__.py
+++ b/dldashboard/__init__.py
@@ -70,7 +70,7 @@ def _dashboard_thread(web_root, ip, port, quiet=True):
     app.run(ip, threaded=True, port=port, ssl_context=ssl_context, debug=False)
 
 
-def start(web_root="web", ip="0.0.0.0", port=80, quiet=True):
+def start(web_root="web", ip="0.0.0.0", port=8000, quiet=True):
     t = threading.Thread(target=_dashboard_thread, args=(web_root, ip, port, quiet))
     t.start()
     # avoid race conditions, wait for the thread to start and set the socketio object

--- a/dldashboard/__init__.py
+++ b/dldashboard/__init__.py
@@ -70,7 +70,7 @@ def _dashboard_thread(web_root, ip, port, quiet=True):
     app.run(ip, threaded=True, port=port, ssl_context=ssl_context, debug=False)
 
 
-def start(web_root="web", ip="0.0.0.0", port=8000, quiet=True):
+def start(web_root="web", ip="0.0.0.0", port=80, quiet=True):
     t = threading.Thread(target=_dashboard_thread, args=(web_root, ip, port, quiet))
     t.start()
     # avoid race conditions, wait for the thread to start and set the socketio object


### PR DESCRIPTION
# Description

Changes the redirect IP from `craftassist.io` to the ECS container IP without the port specified.

We're serving dashboard on port 80, which is the default for websockets.   

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Users visiting `craftassist.io` are still redirected to `<IP>:8000`, which results in an error because dashboard is now served on port 80 (websocket default) in prod.

After this PR, users are taken directly to the container IP.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

