### PR TITLE
Fix craftassist.io deploy and write up instructions

### DIFF
--- a/craftassist/servermgr/README.md
+++ b/craftassist/servermgr/README.md
@@ -68,6 +68,6 @@ git remote add servermgr <Heroku Git URL>
 Check that your remotes were configured properly with `git remote -v`.
 
 To deploy a new servermgr app:
-1. Make changes to the code inside [`~/droidlet/craftassist/servermgr/`](/).
+1. Make changes to the code inside [`~/droidlet/craftassist/servermgr/`]().
 2. Commit and push to your feature branch
 3. Run [deploy.sh](deploy.sh). By default this deploys your working `servermgr` directory to Heroku. (Note: this script needs to be run from within the `servermgr` directory.)

--- a/craftassist/servermgr/README.md
+++ b/craftassist/servermgr/README.md
@@ -68,6 +68,6 @@ git remote add servermgr <Heroku Git URL>
 Check that your remotes were configured properly with `git remote -v`.
 
 To deploy a new servermgr app:
-1. Make changes to the code inside [../servermgr/](`~/droidlet/craftassist/servermgr/`).
+1. Make changes to the code inside [`~/droidlet/craftassist/servermgr/`](/).
 2. Commit and push to your feature branch
 3. Run [deploy.sh](deploy.sh). By default this deploys your working `servermgr` directory to Heroku. (Note: this script needs to be run from within the `servermgr` directory.)

--- a/craftassist/servermgr/README.md
+++ b/craftassist/servermgr/README.md
@@ -68,6 +68,6 @@ git remote add servermgr <Heroku Git URL>
 Check that your remotes were configured properly with `git remote -v`.
 
 To deploy a new servermgr app:
-1. Make changes to the code inside `~/droidlet/craftassist/servermgr/`.
+1. Make changes to the code inside [../servermgr/](`~/droidlet/craftassist/servermgr/`).
 2. Commit and push to your feature branch
 3. Run [deploy.sh](deploy.sh). By default this deploys your working `servermgr` directory to Heroku. (Note: this script needs to be run from within the `servermgr` directory.)

--- a/craftassist/servermgr/README.md
+++ b/craftassist/servermgr/README.md
@@ -45,11 +45,29 @@ Replacing the <DIGEST from above> with whatever digest you'd like to promote
 
 ## How to deploy a new servermgr
 
-0. Do once ever: run `heroku login` and enter the credentials
-and then run: 
+These are instructions for updating `craftassist.io`.
+
+### Set Up
+
+Ensure that you have the Heroku credentials for `servermgr`, and Heroku CLI installed. To set up Heroku CLI, run `heroku login -i` and enter your Heroku credentials. You should be able to see the Heroku apps under your account, including `servermgr` which runs on `craftassist.io`.
+
+### Deploy to craftassist.io
+
+To get the Heroku Git URL, run
 ```
-git remote add <name of heorku git> <link to heroku git>
+heroku info servermgr
 ```
-1. Make changes to the code at [app.py](app.py)
-2. Commit and push to master
-3. Run [deploy.sh](deploy.sh)
+
+In addition to the Git URL this will show you information about the servermgr app, such as link to the web console.
+
+You want to register this Heroku Git URL as a remote for the Droidlet repo. Inside the Droidlet repo, run 
+```
+git remote add servermgr <Heroku Git URL>
+```
+
+Check that your remotes were configured properly with `git remote -v`.
+
+To deploy a new servermgr app:
+1. Make changes to the code inside `~/droidlet/craftassist/servermgr/`.
+2. Commit and push to your feature branch
+3. Run [deploy.sh](deploy.sh). By default this deploys your working `servermgr` directory to Heroku. (Note: this script needs to be run from within the `servermgr` directory.)

--- a/craftassist/servermgr/deploy.sh
+++ b/craftassist/servermgr/deploy.sh
@@ -4,4 +4,4 @@
 
 
 cd $(dirname $0)/../../
-git push heroku_servermgr $(git subtree split --prefix craftassist/servermgr):master --force
+git push servermgr $(git subtree split --prefix craftassist/servermgr):master --force


### PR DESCRIPTION
# Description

The deploy script and instructions for `craftassist.io` are out of date and lacking context. Fixed the deploy script and tested by deploying changes from #272 .

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Without this script, code changes to servermgr have been applied manually across repos. Obviously this is not ideal. 

# Testing

Deployed to `craftassist.io` and verified the fix in #272 was applied.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

