### PR TITLE
robustify heuristic perception in craftassist agent

### DIFF
--- a/craftassist/agent/heuristic_perception.py
+++ b/craftassist/agent/heuristic_perception.py
@@ -519,6 +519,17 @@ def get_all_nearby_holes(agent, location, radius=15, store_inst_seg=True):
     return hole_mems
 
 
+def maybe_get_type_name(idm):
+    try:
+        type_name = BLOCK_DATA["bid_to_name"][idm]
+    except:
+        type_name = "UNK"
+        logging.debug(
+            "heuristic perception encountered unknown block: ({}, {})".format(idm[0], idm[1])
+        )
+    return type_name
+
+
 class PerceptionWrapper:
     """Perceive the world at a given frequency and update agent
     memory.
@@ -563,7 +574,7 @@ class PerceptionWrapper:
                     memid = BlockObjectNode.create(self.agent.memory, obj)
                     color_tags = []
                     for idm in obj:
-                        type_name = BLOCK_DATA["bid_to_name"][idm]
+                        type_name = maybe_get_type_name(idm)
                         color_tags.extend(COLOUR_DATA["name_to_colors"].get(type_name, []))
                     for color_tag in list(set(color_tags)):
                         self.agent.memory.add_triple(
@@ -579,7 +590,7 @@ class PerceptionWrapper:
                 color_tags = []
                 for obj in objs:
                     idm = obj[1]
-                    type_name = BLOCK_DATA["bid_to_name"][idm]
+                    type_name = maybe_get_type_name(idm)
                     color_tags.extend(COLOUR_DATA["name_to_colors"].get(type_name, []))
                 for color_tag in list(set(color_tags)):
                     self.agent.memory.add_triple(


### PR DESCRIPTION
# Description

adds a try/catch to not error out when heuristic perception in craftassist encounter an idm not in our list of blocks 

Fixes # (issue)

https://github.com/facebookresearch/droidlet/issues/327

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

previously if there was a block not in our list, heuristic perception would choke on an index error; now it will log it in debug and move on

# Testing

put a weird block in space in fake world by hand, ran heuristic perception

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

