### PR TITLE
fix memory exist ref obj get memory q's

### DIFF
--- a/base_agent/dialogue_objects/get_memory_handler.py
+++ b/base_agent/dialogue_objects/get_memory_handler.py
@@ -79,6 +79,10 @@ class GetMemoryHandler(DialogueObject):
             all_proximity=ALL_PROXIMITY,
         )
         val_map = get_val_map(self, self.speaker_name, f, get_all=True)
+        if not val_map:
+            # this should be a yes or no question:
+            self.finished = True
+            return "yes" if ref_obj_mems else "no", None
         mems, vals = val_map([m.memid for m in ref_obj_mems], [] * len(ref_obj_mems))
         # back off to tags if nothing else, FIXME do this better!
         if vals:


### PR DESCRIPTION
# Description
Fixes a bug where get_memory does not properly handle memory exists questions "is there an x?"

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After
before this any query about reference objects had to have a value returned (e.g. attribute or count in logical form).  now if there is none, it is assumed that the question is a yes/no about the existence of something in memory

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

