### PR TITLE
Fixed spacy and model version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,13 +22,13 @@ scikit-learn>=0.23.1
 sentry-sdk>=0.7.9
 six>=1.11.0
 snowballstemmer>=1.2.1
-spacy==2.0.12
+spacy==2.3.0
 torch>=1.4.0
 torchvision>=0.5.0
 tqdm>=4.41.1
 word2number>=1.1
 transformers==3.3.1
-https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.0.0/en_core_web_sm-2.0.0.tar.gz
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.0/en_core_web_sm-2.3.0.tar.gz
 coverage>=5.3
 flask-cors>=3.0.9
 flask>=1.1.2


### PR DESCRIPTION
# Description

Fixed the spacy issue mentioned here: #8 to support CUDA 11. Also upgraded spacy model to corresponding version otherwise the mismatch will crash the spacy-related models used by agent.

Fixes #8 

Tested locally and passed. I'll need one of you to try run the following commands to double confirm.

Run these in your devserver:

```
module load cuda/11.0
git clone --depth=1 --recursive https://github.com/facebookresearch/droidlet.git
cd droidlet
conda create -n droidlet_env python==3.7.4 pip numpy scikit-learn==0.19.1 pytorch torchvision
conda activate droidlet_env
pip install --no-cache-dir -r craftassist/requirements.txt
```

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before Pip install requirement file would fail in CUDA 11. After the fix it will succeed.

# Testing

Test locally.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

