### PR TITLE
[Hack Session] Add debug mode to parse tree validation to avoid misleading unit test output

### DIFF
--- a/base_agent/droidlet_nsp_model_wrapper.py
+++ b/base_agent/droidlet_nsp_model_wrapper.py
@@ -167,14 +167,22 @@ class DroidletNSPModelWrapper(SemanticParserWrapper):
             speaker=speaker, logical_form=updated_logical_form, chat=chat
         )
 
-    def validate_parse_tree(self, parse_tree: Dict) -> bool:
-        """Validate the parse tree against current grammar."""
+    def validate_parse_tree(self, parse_tree: Dict, debug: bool = True) -> bool:
+        """Validate the parse tree against current grammar.
+        
+        Args:
+            parse_tree (Dict): logical form to be validated.
+            debug (bool): whether to print error trace for debugging.
+
+        Returns:
+            True if parse tree is valid, False if not.
+        """
         # RefResolver initialization requires a base schema and URI
         schema_dir = "{}/".format(
             pkg_resources.resource_filename("base_agent.documents", "json_schema")
         )
         json_validator = JSONValidator(schema_dir, span_type="all")
-        is_valid_json = json_validator.validate_instance(parse_tree)
+        is_valid_json = json_validator.validate_instance(parse_tree, debug)
         return is_valid_json
 
     def postprocess_logical_form(self, speaker: str, chat: str, logical_form: Dict) -> Dict:

--- a/craftassist/test/test_dialogue_manager.py
+++ b/craftassist/test/test_dialogue_manager.py
@@ -87,8 +87,9 @@ class TestDialogueManager(unittest.TestCase):
             )
 
     def test_validate_bad_json(self):
+        # Don't print debug info on failure since it will be misleading
         is_valid_json = (
-            self.agent.dialogue_manager.semantic_parsing_model_wrapper.validate_parse_tree({})
+            self.agent.dialogue_manager.semantic_parsing_model_wrapper.validate_parse_tree(parse_tree={}, debug=False)
         )
         self.assertFalse(is_valid_json)
 

--- a/craftassist/test/validate_json.py
+++ b/craftassist/test/validate_json.py
@@ -83,18 +83,24 @@ class JSONValidator:
         if test_mode:
             return True
 
-    def validate_instance(self, parse_tree):
+    def validate_instance(self, parse_tree, debug):
         """
         Validates a parse tree instance.
 
         Args:
-        parse_tree (dict) -- dictionary we want to validate
+            parse_tree (dict) -- dictionary we want to validate
+            debug (bool) -- whether to print debug information
+
+        Returns:
+            True if logical form passes the schema validation, else returns False.
         """
         try:
             validate(instance=parse_tree, schema=self.base_schema, resolver=self.resolver)
         except exceptions.ValidationError as e:
-            print("Error validating:\n{}\n".format(parse_tree))
-            print(e)
+            # Option to print debug information
+            if debug:
+                print("Error validating:\n{}\n".format(parse_tree))
+                print(e)
             return False
         return True
 


### PR DESCRIPTION
# Description

As in title. Cleans up data validation unit test outputs from `test_dialogue_manager.py`.

Fixes # (issue)
#316 

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [x] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before: misleading error logs when testing poorly formed parse trees:
P413681278

After: clean unit test outputs
![Screen Shot 2021-05-08 at 6 11 12 PM](https://user-images.githubusercontent.com/19957918/117558083-8b7ad800-b02e-11eb-9ee9-02af3f109c68.png)

# Testing
Tested with unit tests and Minecraft env.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

