### PR TITLE
make locobot_agent work with this new directory structure

### DIFF
--- a/agents/locobot/locobot_agent.py
+++ b/agents/locobot/locobot_agent.py
@@ -7,8 +7,14 @@ import sys
 import subprocess
 import re
 import numpy as np
-import dldashboard
+import time
+import signal
+import random
+import logging
+import faulthandler
+from multiprocessing import set_start_method
 
+from droidlet import dldashboard
 if __name__ == "__main__":
     # this line has to go before any imports that contain @sio.on functions
     # or else, those @sio.on calls become no-ops
@@ -16,28 +22,24 @@ if __name__ == "__main__":
 
 from base_agent.dialogue_manager import DialogueManager
 from base_agent.droidlet_nsp_model_wrapper import DroidletNSPModelWrapper
-from locobot.agent.loco_memory import LocoAgentMemory
 from base_agent.base_util import to_player_struct, Pos, Look, Player, hash_user
 from base_agent.memory_nodes import PlayerNode
 from base_agent.loco_mc_agent import LocoMCAgent
-from locobot.agent.perception import Perception, SelfPerception
 from base_agent.argument_parser import ArgumentParser
-import locobot.agent.default_behaviors as default_behaviors
-from locobot.agent.dialogue_objects import (
+
+from droidlet.memory.loco_memory import LocoAgentMemory
+from droidlet.perception import Perception, SelfPerception
+from droidlet.interpreter import default_behaviors
+
+from droidlet.dialog.dialogue_objects import (
     LocoBotCapabilities,
     LocoGetMemoryHandler,
     PutMemoryHandler,
     LocoInterpreter,
 )
-import locobot.agent.rotation as rotation
-from locobot.agent.locobot_mover import LoCoBotMover
-from multiprocessing import set_start_method
-import time
-import signal
-import random
-import logging
-import faulthandler
-from dlevent import sio
+import droidlet.perception.rotation as rotation
+from droidlet.lowlevel.locobot_mover import LoCoBotMover
+from droidlet.dlevent import sio
 
 BASE_AGENT_ROOT = os.path.join(os.path.dirname(__file__), "../../")
 SCHEMAS = [os.path.join(os.path.join(BASE_AGENT_ROOT, "base_agent"), "base_memory_schema.sql")]

--- a/base_agent/droidlet_nsp_model_wrapper.py
+++ b/base_agent/droidlet_nsp_model_wrapper.py
@@ -27,7 +27,7 @@ from base_agent.base_util import hash_user
 # TODO: move JSONValidator into base
 from craftassist.test.validate_json import JSONValidator
 from base_agent.dialogue_model import DroidletSemanticParsingModel
-from dlevent import sio
+from droidlet.dlevent import sio
 from .nsp_logger import NSPLogger
 
 spacy_model = spacy.load("en_core_web_sm")

--- a/base_agent/loco_mc_agent.py
+++ b/base_agent/loco_mc_agent.py
@@ -5,11 +5,12 @@ import logging
 import random
 import re
 import time
+import os
 import numpy as np
 
 from .core import BaseAgent
 from base_agent.base_util import ErrorWithResponse
-from dlevent import sio
+from droidlet.dlevent import sio
 
 from .base_util import hash_user
 from .save_and_fetch_commands import *

--- a/droidlet/dialog/dialogue_objects/get_memory_handler.py
+++ b/droidlet/dialog/dialogue_objects/get_memory_handler.py
@@ -19,7 +19,7 @@ from base_agent.memory_nodes import MemoryNode, ReferenceObjectNode
 from base_agent.string_lists import ACTION_ING_MAPPING
 from base_agent.ttad.generation_dialogues.generate_utils import prepend_a_an
 from copy import deepcopy
-from locobot.agent.tasks import Point
+from droidlet.interpreter.tasks import Point
 
 
 class LocoGetMemoryHandler(GetMemoryHandler):

--- a/droidlet/dialog/dialogue_objects/loco_interpreter.py
+++ b/droidlet/dialog/dialogue_objects/loco_interpreter.py
@@ -20,8 +20,8 @@ from .spatial_reasoning import ComputeLocations
 from .facing_helper import FacingInterpreter
 from .point_target import PointTargetInterpreter
 
-import locobot.agent.dance as dance
-import locobot.agent.tasks as tasks
+import droidlet.interpreter.dance as dance
+import droidlet.interpreter.tasks as tasks
 
 
 def post_process_loc(loc, interpreter):

--- a/droidlet/dldashboard/__init__.py
+++ b/droidlet/dldashboard/__init__.py
@@ -3,7 +3,7 @@ import threading
 from flask import Flask
 import socketio
 from flask_cors import cross_origin, CORS
-import dlevent
+from droidlet import dlevent
 import logging
 import json
 import random

--- a/droidlet/interpreter/dance.py
+++ b/droidlet/interpreter/dance.py
@@ -4,13 +4,10 @@ Copyright (c) Facebook, Inc. and its affiliates.
 
 """This file has functions to implement different dances for the agent.
 """
-from locobot.agent.tasks import Move, Dance
 import time
 import math
 
-# import search
-# from base_util import ErrorWithResponse
-
+from .tasks import Move, Dance
 
 konami_dance = [
     {"translate": (0, 1, 0)},
@@ -75,62 +72,3 @@ def generate_sequential_move_fn(sequence):
         return mv
 
     return move_fn
-
-
-# TODO head bob
-
-# class HeadTurnInstant(Movement):
-
-
-# TODO: class TimedDance(Movement): !!!!
-
-
-# # e.g. go around the x
-# #     go through the x
-# #     go over the x
-# #     go across the x
-# class RefObjMovement(Movement):
-#     def __init__(
-#         self,
-#         agent,
-#         ref_object=None,
-#         relative_direction="CLOCKWISE",  # this is the memory of the object
-#     ):
-#         self.agent = agent
-#         self.tick = 0
-#         if ref_object is None or ref_object == "AGENT_POS":
-#             x, y, z = agent.pos
-#             bounds = (x, x, y, y, z, z)
-#             center = (x, y, z)
-#         else:
-#             bounds = ref_object.get_bounds()
-#             center = ref_object.get_pos()
-#         d = max(bounds[1] - bounds[0], bounds[3] - bounds[2], bounds[5] - bounds[4])
-#         if relative_direction == "CLOCKWISE":
-#             offsets = shapes.arrange(
-#                 "circle", schematic=None, shapeparams={"encircled_object_radius": d}
-#             )
-#         elif relative_direction == "ANTICLOCKWISE":
-#             offsets = shapes.arrange(
-#                 "circle", schematic=None, shapeparams={"encircled_object_radius": d}
-#             )
-#             offsets = offsets[::-1]
-#         else:
-#             raise NotImplementedError("TODO other kinds of paths")
-#         self.path = [np.round(np.add(center, o)) for o in offsets]
-#         self.path.append(self.path[0])
-
-#         # check each offset to find a nearby reachable point, see if a path
-#         # is possible now, and error otherwise
-
-#         for i in range(len(self.path) - 1):
-#             path = search.astar(agent, self.path[i + 1], approx=2, pos=self.path[i])
-#             if path is None:
-#                 raise ErrorWithResponse("I cannot find an appropriate path.")
-
-#     def get_move(self):
-#         if self.tick >= len(self.path):
-#             return None
-#         mv = tasks.Move(self.agent, {"target": self.path[self.tick], "approx": 2})
-#         self.tick += 1
-#         return mv

--- a/droidlet/interpreter/default_behaviors.py
+++ b/droidlet/interpreter/default_behaviors.py
@@ -2,7 +2,7 @@
 Copyright (c) Facebook, Inc. and its affiliates.
 """
 import logging
-import locobot.agent.tasks as tasks
+from . import tasks
 
 
 def explore(agent):

--- a/droidlet/interpreter/tasks.py
+++ b/droidlet/interpreter/tasks.py
@@ -2,17 +2,18 @@
 Copyright (c) Facebook, Inc. and its affiliates.
 """
 
-import numpy as np
+import time
 import logging
+import numpy as np
 
 from base_agent.task import Task, BaseMovementTask
 from base_agent.memory_nodes import TaskNode
 from base_agent.task import Task
-from locobot.agent.objects import DanceMovement
-from locobot.agent.rotation import yaw_pitch
 
-import time
-from locobot.agent.locobot_mover_utils import (
+from droidlet.interpreter.objects import DanceMovement
+from droidlet.perception.rotation import yaw_pitch
+
+from droidlet.lowlevel.locobot_mover_utils import (
     get_move_target_for_point,
     CAMERA_HEIGHT,
     ARM_HEIGHT,

--- a/droidlet/lowlevel/locobot_mover.py
+++ b/droidlet/lowlevel/locobot_mover.py
@@ -1,28 +1,29 @@
 """
 Copyright (c) Facebook, Inc. and its affiliates.
 """
-import Pyro4
-import logging
-import numpy as np
-
 import os
 import sys
+import math
+import copy
+import time
+import logging
+from collections.abc import Iterable
+
+import Pyro4
+import numpy as np
+
 
 if "/opt/ros/kinetic/lib/python2.7/dist-packages" in sys.path:
     sys.path.remove("/opt/ros/kinetic/lib/python2.7/dist-packages")
 
 import cv2
-import os
-import math
-import copy
-import time
+from prettytable import PrettyTable
+
 from base_agent.base_util import ErrorWithResponse
 from base_agent.argument_parser import ArgumentParser
-from prettytable import PrettyTable
-from locobot.agent.perception import RGBDepth
-from locobot.agent.objects import Marker, Pos
-from collections.abc import Iterable
-from locobot.agent.locobot_mover_utils import (
+from droidlet.perception import RGBDepth
+from droidlet.interpreter.objects import Marker, Pos
+from droidlet.lowlevel.locobot_mover_utils import (
     get_camera_angles,
     angle_diff,
     MAX_PAN_RAD,

--- a/droidlet/lowlevel/locobot_mover_utils.py
+++ b/droidlet/lowlevel/locobot_mover_utils.py
@@ -3,8 +3,9 @@ Copyright (c) Facebook, Inc. and its affiliates.
 """
 import numpy as np
 import logging
-from locobot.agent.rotation import yaw_pitch
 from scipy.spatial.transform import Rotation
+
+from droidlet.perception.rotation import yaw_pitch
 
 MAX_PAN_RAD = np.pi / 4
 CAMERA_HEIGHT = 0.6

--- a/droidlet/memory/loco_memory.py
+++ b/droidlet/memory/loco_memory.py
@@ -5,10 +5,12 @@ Copyright (c) Facebook, Inc. and its affiliates.
 import os
 import logging
 from typing import List
-from locobot.agent.dance import add_default_dances
-from locobot.agent.loco_memory_nodes import *
+
 from base_agent.memory_nodes import PlayerNode
 from base_agent.sql_memory import AgentMemory
+
+from droidlet.interpreter.dance import add_default_dances
+from droidlet.memory.loco_memory_nodes import *
 
 BASE_AGENT_ROOT = os.path.join(os.path.dirname(__file__), "../..")
 SCHEMAS = [

--- a/droidlet/perception/handlers/core.py
+++ b/droidlet/perception/handlers/core.py
@@ -3,19 +3,19 @@ Copyright (c) Facebook, Inc. and its affiliates.
 """
 
 import logging
-import numpy as np
 import sys
 import os
 import open3d as o3d
+from abc import abstractmethod
+import numpy as np
+from PIL import Image
 
 if "/opt/ros/kinetic/lib/python2.7/dist-packages" in sys.path:
     sys.path.remove("/opt/ros/kinetic/lib/python2.7/dist-packages")
 import cv2
-from abc import abstractmethod
-from PIL import Image
-from locobot.agent.perception import get_color_tag
-from locobot.agent.locobot_mover_utils import xyz_pyrobot_to_canonical_coords
 
+from ..perception_helpers import get_color_tag
+from droidlet.lowlevel.locobot_mover_utils import xyz_pyrobot_to_canonical_coords
 
 class AbstractHandler:
     """Interface for implementing perception handlers.

--- a/droidlet/perception/handlers/deduplicater.py
+++ b/droidlet/perception/handlers/deduplicater.py
@@ -1,13 +1,14 @@
 """
 Copyright (c) Facebook, Inc. and its affiliates.
 """
-from .core import AbstractHandler
-from locobot.agent.objects import AttributeDict
+import logging
+import numpy as np
 import torch
 import torchvision.models as models
-import numpy as np
-import logging
 from torchvision import transforms
+
+from .core import AbstractHandler
+from droidlet.interpreter.objects import AttributeDict
 
 
 class ObjectDeduplicationHandler(AbstractHandler):

--- a/droidlet/perception/handlers/detector.py
+++ b/droidlet/perception/handlers/detector.py
@@ -6,18 +6,21 @@ import os
 import sys
 import cv2
 import numpy as np
-import locobot.agent.loco_memory as loco_memory
 import pickle
 import tempfile
 import logging
+
 from detectron2.data import MetadataCatalog
 from detectron2.utils.visualizer import ColorMode
-from locobot.agent.detectron.detector.utils import get_predictor
 from detectron2.config import get_cfg
 from detectron2.engine.defaults import DefaultPredictor
-from locobot.agent.detectron.detector.visualizer import LocobotVisualizer
+
+import droidlet.memory.loco_memory as loco_memory
+
 from .core import AbstractHandler, WorldObject, RGBDepth
-from locobot.agent.perception.perception_helpers import get_color_tag
+from ..detectron.detector.utils import get_predictor
+from ..detectron.detector.visualizer import LocobotVisualizer
+from ..perception_helpers import get_color_tag
 
 
 lvis_yaml = "configs/mask_rcnn_R_101_FPN_1x.yaml"

--- a/droidlet/perception/handlers/human_pose.py
+++ b/droidlet/perception/handlers/human_pose.py
@@ -4,7 +4,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 import cv2
 import os
 import logging
-import locobot.agent.loco_memory as loco_memory
+import droidlet.memory.loco_memory as loco_memory
 import numpy as np
 from .core import AbstractHandler, WorldObject, RGBDepth
 from detectron2.config import get_cfg
@@ -88,7 +88,7 @@ class HumanPose:
 
     def __init__(self, model_data_dir):
         cfg = get_cfg()
-        yaml_path = os.path.abspath(os.path.join(file_root, "../..", keypoints_yaml))
+        yaml_path = os.path.abspath(os.path.join(file_root, "..", keypoints_yaml))
         cfg.merge_from_file(yaml_path)
         weights = os.path.join(model_data_dir, keypoints_weights)
         cfg.MODEL.WEIGHTS = weights

--- a/droidlet/perception/handlers/memory.py
+++ b/droidlet/perception/handlers/memory.py
@@ -1,14 +1,15 @@
 """
 Copyright (c) Facebook, Inc. and its affiliates.
 """
-from .core import AbstractHandler
+import logging
+import numpy as np
 import torch
 import torchvision.models as models
-import numpy as np
-import locobot.agent.loco_memory as loco_memory
-import logging
 from torchvision import transforms
-from dlevent import sio
+
+from .core import AbstractHandler
+import droidlet.memory.loco_memory as loco_memory
+from droidlet.dlevent import sio
 
 
 class MemoryHandler(AbstractHandler):

--- a/droidlet/perception/perception.py
+++ b/droidlet/perception/perception.py
@@ -1,6 +1,9 @@
 """
 Copyright (c) Facebook, Inc. and its affiliates.
 """
+import time
+import queue
+
 from .handlers import (
     InputHandler,
     DetectionHandler,
@@ -11,14 +14,11 @@ from .handlers import (
     LaserPointerHandler,
     ObjectDeduplicationHandler,
 )
-import time
-from locobot.agent.objects import AttributeDict
-from dlevent import sio
+from droidlet.interpreter.objects import AttributeDict
+from droidlet.dlevent import sio
 
 from torch import multiprocessing as mp
-
 multiprocessing = mp.get_context("spawn")
-import queue
 
 
 class SlowPerception:

--- a/tools/data_scripts/try_download.sh
+++ b/tools/data_scripts/try_download.sh
@@ -24,7 +24,7 @@ else
     AGENT=$1
 fi
 
-AGENT_PATH="${ROOTDIR}/${AGENT}/agent/"
+AGENT_PATH="${ROOTDIR}/agents/${AGENT}/"
 echo "agent path ${AGENT_PATH}"
 
 # in case directories don't even exist, create them


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #410 improve craftassist makefiles
* #409 add cmake modules to find glog and gflags
* #408 move locobot's perception into a robot/ folder temporarily
* #407 fix pytest path in craftassist/test/test.sh
* #405 fix circleci base_agent tests path
* #395 move more files from craftassist to droidlet/*
* #394 move minecraft_specs -> specs
* #392 move some craftassist files into droidlet
* #391 fix craftassist tests
* #390 small fix in locobot after rebase
* #389 fix circleci tests
* #396 change some base_agent references
* #388 fix craftassist tests after base_agent move
* #387 fixes after base_agent move
* #386 move droidlet/*/* into a droidlet/*/robot/* subfolder, and move base_agent files into their appropriate droidlet/ subfolder equivalents
* #385 droidlet.dldashboard -> droidlet.dashboard
* #384 droidlet.dlevent -> droidlet.event
* #383 move locobot/remote to lowlevel
* #382 move tests from locobot folder into droidlet folder
* **#381 make locobot_agent work with this new directory structure**
* #380 move locobot files into new directory structure

