### PR TITLE
fix craftassist tests after base_agent move

### DIFF
--- a/agents/locobot/locobot_agent.py
+++ b/agents/locobot/locobot_agent.py
@@ -41,9 +41,6 @@ import droidlet.lowlevel.locobot.rotation as rotation
 from droidlet.lowlevel.locobot.locobot_mover import LoCoBotMover
 from droidlet.event import sio
 
-BASE_AGENT_ROOT = os.path.join(os.path.dirname(__file__), "../../")
-# SCHEMAS = [os.path.join(os.path.join(BASE_AGENT_ROOT, "base_agent"), "base_memory_schema.sql")]
-
 faulthandler.register(signal.SIGUSR1)
 
 random.seed(0)

--- a/craftassist/agent/craftassist_agent.py
+++ b/craftassist/agent/craftassist_agent.py
@@ -22,7 +22,7 @@ from craftassist.agent import mc_memory
 from craftassist.agent import rotation
 
 
-import dashboard
+import droidlet.dashboard
 
 if __name__ == "__main__":
     # this line has to go before any imports that contain @sio.on functions
@@ -44,7 +44,7 @@ from craftassist.agent.dialogue_objects import (
 )
 from craftassist.agent.low_level_perception import LowLevelMCPerception
 from craftassist.agent.mc_agent import Agent as MCAgent
-from event import sio
+from droidlet.event import sio
 from craftassist.agent.mc_util import cluster_areas, MCTime
 from craftassist.agent.voxel_models.subcomponent_classifier import SubcomponentClassifierWrapper
 

--- a/craftassist/agent/default_behaviors.py
+++ b/craftassist/agent/default_behaviors.py
@@ -13,7 +13,7 @@ from .mc_util import pos_to_np
 
 
 from droidlet.dialog.dialogue_objects import Say
-from droidlet.dialog.ttad.generation_dialogues import prepend_a_an
+from droidlet.dialog.ttad.generation_dialogues.generate_utils import prepend_a_an
 
 """This file contains functions that the agent can perform 
 at random when not following player instructions or interacting with the

--- a/craftassist/agent/mc_memory.py
+++ b/craftassist/agent/mc_memory.py
@@ -43,11 +43,11 @@ from .mc_memory_nodes import (  # noqa
 
 from .word_maps import SPAWN_OBJECTS
 
-BASE_AGENT_ROOT = os.path.join(os.path.dirname(__file__), "../../")
+ROOT_DIR = os.path.join(os.path.dirname(__file__), "../../")
 
 # TODO: ship these schemas via setup.py and fix these directory references
 SCHEMAS = [
-    os.path.join(os.path.join(BASE_AGENT_ROOT, "base_agent"), "base_memory_schema.sql"),
+    os.path.join(os.path.join(ROOT_DIR, "droidlet", "memory"), "base_memory_schema.sql"),
     os.path.join(os.path.dirname(__file__), "mc_memory_schema.sql"),
 ]
 

--- a/craftassist/test/base_craftassist_test_case.py
+++ b/craftassist/test/base_craftassist_test_case.py
@@ -7,13 +7,14 @@ import numpy as np
 from typing import List, Sequence, Dict
 
 from craftassist.agent.build_utils import to_relative_pos
-from droidlet.dialog.dialogue_objects import AwaitResponse
-from fake_agent import FakeAgent, FakePlayer
 from craftassist.agent.mc_memory_nodes import VoxelObjectNode
 from craftassist.agent.mc_util import XYZ, Block, IDM
-from utils import Player, Pos, Look, Item, Look
-from world import World, Opt, flat_ground_generator
 from craftassist.agent.rotation import yaw_pitch
+from droidlet.dialog.dialogue_objects import AwaitResponse
+
+from .fake_agent import FakeAgent, FakePlayer
+from .utils import Player, Pos, Look, Item, Look
+from .world import World, Opt, flat_ground_generator
 
 
 class BaseCraftassistTestCase(unittest.TestCase):

--- a/craftassist/test/fake_agent.py
+++ b/craftassist/test/fake_agent.py
@@ -7,7 +7,7 @@ import numpy as np
 from typing import List
 
 from craftassist.agent.mc_util import XYZ, IDM, Block
-from utils import Look, Pos, Item, Player
+from .utils import Look, Pos, Item, Player
 from agents.loco_mc_agent import LocoMCAgent
 from droidlet.base_util import TICKS_PER_SEC
 from craftassist.agent.mc_memory import MCAgentMemory

--- a/craftassist/test/fake_mobs.py
+++ b/craftassist/test/fake_mobs.py
@@ -2,7 +2,7 @@
 Copyright (c) Facebook, Inc. and its affiliates.
 """
 import numpy as np
-from utils import Pos, Look
+from .utils import Pos, Look
 from craftassist.agent.entities import MOBS_BY_ID
 
 FLAT_GROUND_DEPTH = 8

--- a/craftassist/test/test_agent.py
+++ b/craftassist/test/test_agent.py
@@ -3,7 +3,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 """
 
 import unittest
-from fake_agent import MockOpt
+from .fake_agent import MockOpt
 
 from craftassist.agent.craftassist_agent import CraftAssistAgent
 

--- a/craftassist/test/test_conditions.py
+++ b/craftassist/test/test_conditions.py
@@ -5,10 +5,10 @@ import unittest
 import numpy as np
 
 from copy import deepcopy
-from base_craftassist_test_case import BaseCraftassistTestCase
 from droidlet.interpreter.tests.all_test_commands import *
-from fake_mobs import LoopMob, make_mob_opts
 from droidlet.base_util import TICKS_PER_SEC
+from .base_craftassist_test_case import BaseCraftassistTestCase
+from .fake_mobs import LoopMob, make_mob_opts
 
 
 def add_sequence_mob(test, mobname, sequence):

--- a/craftassist/test/test_coref_resolve.py
+++ b/craftassist/test/test_coref_resolve.py
@@ -5,7 +5,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
 import craftassist.agent.shapes as shapes
-from base_craftassist_test_case import BaseCraftassistTestCase
+from .base_craftassist_test_case import BaseCraftassistTestCase
 from droidlet.interpreter.tests.all_test_commands import *
 
 

--- a/craftassist/test/test_dialogue_manager.py
+++ b/craftassist/test/test_dialogue_manager.py
@@ -9,7 +9,7 @@ from droidlet.dialog.dialogue_manager import DialogueManager
 from droidlet.dialog.droidlet_nsp_model_wrapper import DroidletNSPModelWrapper
 from agents.loco_mc_agent import LocoMCAgent
 from droidlet.interpreter.tests.all_test_commands import *
-from fake_agent import MockOpt
+from .fake_agent import MockOpt
 
 
 class AttributeDict(dict):

--- a/craftassist/test/test_dialogue_object_utils.py
+++ b/craftassist/test/test_dialogue_object_utils.py
@@ -6,7 +6,7 @@ import re
 import unittest
 from copy import deepcopy
 from droidlet.dialog.dialogue_objects import process_spans_and_remove_fixed_value
-from test_y_print_parsing_report import common_functional_commands, compare_full_dictionaries
+from .test_y_print_parsing_report import common_functional_commands, compare_full_dictionaries
 
 logical_form_before_processing = {
     "turn right": common_functional_commands["turn right"],

--- a/craftassist/test/test_filters.py
+++ b/craftassist/test/test_filters.py
@@ -4,7 +4,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
 import craftassist.agent.shapes as shapes
-from base_craftassist_test_case import BaseCraftassistTestCase
+from .base_craftassist_test_case import BaseCraftassistTestCase
 from droidlet.dialog.dialogue_stack import DialogueStack
 from craftassist.agent.dialogue_objects import DummyInterpreter
 import droidlet.interpreter.tests.all_test_commands

--- a/craftassist/test/test_get_memory.py
+++ b/craftassist/test/test_get_memory.py
@@ -3,7 +3,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 """
 import unittest
 import craftassist.agent.shapes as shapes
-from base_craftassist_test_case import BaseCraftassistTestCase
+from .base_craftassist_test_case import BaseCraftassistTestCase
 from droidlet.interpreter.tests.all_test_commands import *
 
 

--- a/craftassist/test/test_greeting.py
+++ b/craftassist/test/test_greeting.py
@@ -4,8 +4,8 @@ Copyright (c) Facebook, Inc. and its affiliates.
 
 import unittest
 import os
-from fake_agent import MockOpt
-from base_craftassist_test_case import BaseCraftassistTestCase
+from .fake_agent import MockOpt
+from .base_craftassist_test_case import BaseCraftassistTestCase
 
 GROUND_TRUTH_DATA_DIR = os.path.join(os.path.dirname(__file__), "../agent/datasets/ground_truth/")
 

--- a/craftassist/test/test_interpreter.py
+++ b/craftassist/test/test_interpreter.py
@@ -3,15 +3,15 @@ Copyright (c) Facebook, Inc. and its affiliates.
 """
 import unittest
 from unittest.mock import Mock
+from typing import List
 
 import craftassist.agent.heuristic_perception as heuristic_perception
 import craftassist.agent.shapes as shapes
 from droidlet.dialog.dialogue_objects import SPEAKERLOOK
-from base_craftassist_test_case import BaseCraftassistTestCase
 from droidlet.base_util import NextDialogueStep
-from typing import List
 from craftassist.agent.mc_util import Block, strip_idmeta, euclid_dist
 from droidlet.interpreter.tests.all_test_commands import *
+from .base_craftassist_test_case import BaseCraftassistTestCase
 
 
 def add_two_cubes(test):
@@ -331,6 +331,8 @@ class FillTest(BaseCraftassistTestCase):
         self.hole_poss = [(x, 62, z) for x in (8, 9) for z in (10, 11)]
         self.set_blocks([(pos, (0, 0)) for pos in self.hole_poss])
         self.set_looking_at(self.hole_poss[0])
+
+    def test_looking_at(self):
         self.assertEqual(set(self.get_idm_at_locs(self.hole_poss).values()), set([(0, 0)]))
 
     def test_fill_that(self):

--- a/craftassist/test/test_memory.py
+++ b/craftassist/test/test_memory.py
@@ -6,10 +6,10 @@ import unittest
 
 import craftassist.agent.shapes as shapes
 from craftassist.agent.mc_memory import MCAgentMemory
-from utils import Mob, Pos, Look
 from craftassist.agent.entities import MOBS_BY_ID
-from base_craftassist_test_case import BaseCraftassistTestCase
 from droidlet.interpreter.tests.all_test_commands import *
+from .base_craftassist_test_case import BaseCraftassistTestCase
+from .utils import Mob, Pos, Look
 
 
 class ObjectsTest(BaseCraftassistTestCase):

--- a/craftassist/test/test_put_memory.py
+++ b/craftassist/test/test_put_memory.py
@@ -5,7 +5,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
 import craftassist.agent.shapes as shapes
-from base_craftassist_test_case import BaseCraftassistTestCase
+from .base_craftassist_test_case import BaseCraftassistTestCase
 from droidlet.interpreter.tests.all_test_commands import *
 
 

--- a/craftassist/test/test_safety.py
+++ b/craftassist/test/test_safety.py
@@ -5,8 +5,8 @@ Copyright (c) Facebook, Inc. and its affiliates.
 import os
 import unittest
 
-from base_craftassist_test_case import BaseCraftassistTestCase
-from fake_agent import MockOpt
+from .base_craftassist_test_case import BaseCraftassistTestCase
+from .fake_agent import MockOpt
 
 TTAD_BERT_DATA_DIR = os.path.join(os.path.dirname(__file__), "../agent/datasets/annotated_data/")
 

--- a/craftassist/test/test_undo.py
+++ b/craftassist/test/test_undo.py
@@ -6,8 +6,8 @@ import unittest
 import time
 import craftassist.agent.shapes as shapes
 from droidlet.dialog.dialogue_objects import AwaitResponse
-from base_craftassist_test_case import BaseCraftassistTestCase
 from droidlet.interpreter.tests.all_test_commands import *
+from .base_craftassist_test_case import BaseCraftassistTestCase
 
 
 class UndoTest(BaseCraftassistTestCase):

--- a/craftassist/test/test_validate_dataset.py
+++ b/craftassist/test/test_validate_dataset.py
@@ -5,11 +5,11 @@ Copyright (c) Facebook, Inc. and its affiliates.
 import os
 import unittest
 
-from base_craftassist_test_case import BaseCraftassistTestCase
-from validate_json import JSONValidator
+from .base_craftassist_test_case import BaseCraftassistTestCase
+from .validate_json import JSONValidator
 
 FULL_DATA_DIR = os.path.join(os.path.dirname(__file__), "../agent/datasets/full_data/")
-SCHEMA_DIR = os.path.join(os.path.dirname(__file__), "../../base_agent/documents/json_schema/")
+SCHEMA_DIR = os.path.join(os.path.dirname(__file__), "../../droidlet/memory/documents/json_schema/")
 
 
 class DataValidationTest(BaseCraftassistTestCase):

--- a/craftassist/test/test_with_model.py
+++ b/craftassist/test/test_with_model.py
@@ -7,8 +7,8 @@ import unittest
 
 import craftassist.agent.shapes as shapes
 from craftassist.agent.mc_util import euclid_dist
-from base_craftassist_test_case import BaseCraftassistTestCase
-from fake_agent import MockOpt
+from .base_craftassist_test_case import BaseCraftassistTestCase
+from .fake_agent import MockOpt
 
 
 TTAD_MODEL_DIR = os.path.join(os.path.dirname(__file__), "../agent/models/semantic_parser/")

--- a/craftassist/test/test_y_print_parsing_report.py
+++ b/craftassist/test/test_y_print_parsing_report.py
@@ -8,7 +8,7 @@ import json
 from droidlet.dialog.dialogue_manager import DialogueManager
 from droidlet.dialog.droidlet_nsp_model_wrapper import DroidletNSPModelWrapper
 from agents.loco_mc_agent import LocoMCAgent
-from fake_agent import MockOpt
+from .fake_agent import MockOpt
 from prettytable import PrettyTable
 
 

--- a/craftassist/test/world.py
+++ b/craftassist/test/world.py
@@ -5,7 +5,7 @@ import numpy as np
 from typing import Sequence, Dict
 from craftassist.agent.mc_util import Block, XYZ, IDM
 from craftassist.agent.rotation import look_vec
-from fake_mobs import make_mob_opts, MOB_META, SimpleMob
+from .fake_mobs import make_mob_opts, MOB_META, SimpleMob
 
 FLAT_GROUND_DEPTH = 8
 

--- a/droidlet/dialog/droidlet_nsp_model_wrapper.py
+++ b/droidlet/dialog/droidlet_nsp_model_wrapper.py
@@ -182,7 +182,7 @@ class DroidletNSPModelWrapper(SemanticParserWrapper):
         """
         # RefResolver initialization requires a base schema and URI
         schema_dir = "{}/".format(
-            pkg_resources.resource_filename("base_agent.documents", "json_schema")
+            pkg_resources.resource_filename("droidlet.memory.documents", "json_schema")
         )
         json_validator = JSONValidator(schema_dir, span_type="all")
         is_valid_json = json_validator.validate_instance(parse_tree, debug)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #410 improve craftassist makefiles
* #409 add cmake modules to find glog and gflags
* #408 move locobot's perception into a robot/ folder temporarily
* #407 fix pytest path in craftassist/test/test.sh
* #405 fix circleci base_agent tests path
* #395 move more files from craftassist to droidlet/*
* #394 move minecraft_specs -> specs
* #392 move some craftassist files into droidlet
* #391 fix craftassist tests
* #390 small fix in locobot after rebase
* #389 fix circleci tests
* #396 change some base_agent references
* **#388 fix craftassist tests after base_agent move**
* #387 fixes after base_agent move
* #386 move droidlet/*/* into a droidlet/*/robot/* subfolder, and move base_agent files into their appropriate droidlet/ subfolder equivalents
* #385 droidlet.dldashboard -> droidlet.dashboard
* #384 droidlet.dlevent -> droidlet.event
* #383 move locobot/remote to lowlevel
* #382 move tests from locobot folder into droidlet folder
* #381 make locobot_agent work with this new directory structure
* #380 move locobot files into new directory structure

