### PR TITLE
fix craftassist tests

### DIFF
--- a/craftassist/agent/craftassist_agent.py
+++ b/craftassist/agent/craftassist_agent.py
@@ -22,7 +22,7 @@ from craftassist.agent import mc_memory
 from craftassist.agent import rotation
 
 
-import droidlet.dashboard
+import droidlet.dashboard as dashboard
 
 if __name__ == "__main__":
     # this line has to go before any imports that contain @sio.on functions

--- a/craftassist/agent/mc_memory.py
+++ b/craftassist/agent/mc_memory.py
@@ -43,11 +43,10 @@ from .mc_memory_nodes import (  # noqa
 
 from .word_maps import SPAWN_OBJECTS
 
-ROOT_DIR = os.path.join(os.path.dirname(__file__), "../../")
 
 # TODO: ship these schemas via setup.py and fix these directory references
 SCHEMAS = [
-    os.path.join(os.path.join(ROOT_DIR, "droidlet", "memory"), "base_memory_schema.sql"),
+    os.path.join(os.path.dirname(__file__), "..", "base_memory_schema.sql"),
     os.path.join(os.path.dirname(__file__), "mc_memory_schema.sql"),
 ]
 

--- a/craftassist/test/base_craftassist_test_case.py
+++ b/craftassist/test/base_craftassist_test_case.py
@@ -22,7 +22,7 @@ class BaseCraftassistTestCase(unittest.TestCase):
         if not players:
             players = [
                 FakePlayer(
-                    Player(42, "SPEAKER", Pos(5, 63, 5), Look(270, 0), Item(0, 0)), active=False
+                    Player(42, "SPEAKER", Pos(5, 63, 5), Look(270, 0), Item(0, 0)), active=False, opts=agent_opts
                 )
             ]
         spec = {

--- a/craftassist/test/fake_agent.py
+++ b/craftassist/test/fake_agent.py
@@ -570,7 +570,7 @@ class FakePlayer(FakeAgent):
     def __init__(
         self,
         struct=None,
-        opts=None,
+        opts=(),
         do_heuristic_perception=False,
         get_world_pos=False,
         name="",

--- a/craftassist/test/test_filters.py
+++ b/craftassist/test/test_filters.py
@@ -61,8 +61,8 @@ class FiltersTest(BaseCraftassistTestCase):
         self.assertEqual(vals[0], 64)
 
     def test_random(self):
-        o = base_agent.test.all_test_commands.FILTERS["a random cube"]
-        t = base_agent.test.all_test_commands.FILTERS["two random cubes"]
+        o = droidlet.interpreter.tests.all_test_commands.FILTERS["a random cube"]
+        t = droidlet.interpreter.tests.all_test_commands.FILTERS["two random cubes"]
 
         DI = self.dummy_interpreter
 

--- a/craftassist/test/test_safety.py
+++ b/craftassist/test/test_safety.py
@@ -9,6 +9,7 @@ from .base_craftassist_test_case import BaseCraftassistTestCase
 from .fake_agent import MockOpt
 
 TTAD_BERT_DATA_DIR = os.path.join(os.path.dirname(__file__), "../agent/datasets/annotated_data/")
+TTAD_BERT_MODEL_DIR = os.path.join(os.path.dirname(__file__), "../agent/models/semantic_parser/")
 
 """This class tests safety checks using a preset list of blacklisted words.
 """
@@ -18,6 +19,7 @@ class SafetyTest(BaseCraftassistTestCase):
     def setUp(self):
         opts = MockOpt()
         opts.nsp_data_dir = TTAD_BERT_DATA_DIR
+        opts.nsp_models_dir = TTAD_BERT_MODEL_DIR
         opts.no_ground_truth = False
         super().setUp(agent_opts=opts)
 

--- a/droidlet/dialog/droidlet_nsp_model_wrapper.py
+++ b/droidlet/dialog/droidlet_nsp_model_wrapper.py
@@ -49,6 +49,8 @@ class DroidletNSPModelWrapper(SemanticParserWrapper):
                 opts.nsp_models_dir, opts.nsp_data_dir
             )
         except NotADirectoryError:
+            # TODO: this class only partially works if self.parsing_model is not present
+            # remove this try/catch and make this class more robust to this failure?
             pass
 
         # Socket event listener
@@ -70,7 +72,7 @@ class DroidletNSPModelWrapper(SemanticParserWrapper):
         # Extract the set of safety words from safety file
         self.safety_words = set()
         safety_words_path = "{}/{}".format(
-            pkg_resources.resource_filename("base_agent.documents", "internal"),
+            pkg_resources.resource_filename("droidlet.memory.documents", "internal"),
             "safety.txt",
         )
         if os.path.isfile(safety_words_path):

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN tar -cvzf client_ccache.tar.gz /cache/.ccache
 RUN AWS_ACCESS_KEY_ID=$(cat /AWS_S3_ACCESS_KEY_ID.txt) AWS_SECRET_ACCESS_KEY=$(cat /AWS_S3_SECRET_ACCESS_KEY.txt) aws s3 cp client_ccache.tar.gz s3://craftassist/pubr/client_ccache.tar.gz
 
 RUN npm install -g yarn
-RUN cd /droidlet/dldashboard/web && yarn install
+RUN cd /droidlet/droidlet/dashboard/web && yarn install
 
 RUN mkdir workdir
 WORKDIR workdir


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #410 improve craftassist makefiles
* #409 add cmake modules to find glog and gflags
* #408 move locobot's perception into a robot/ folder temporarily
* #407 fix pytest path in craftassist/test/test.sh
* #405 fix circleci base_agent tests path
* #395 move more files from craftassist to droidlet/*
* #394 move minecraft_specs -> specs
* #392 move some craftassist files into droidlet
* **#391 fix craftassist tests**
* #390 small fix in locobot after rebase
* #389 fix circleci tests
* #396 change some base_agent references
* #388 fix craftassist tests after base_agent move
* #387 fixes after base_agent move
* #386 move droidlet/*/* into a droidlet/*/robot/* subfolder, and move base_agent files into their appropriate droidlet/ subfolder equivalents
* #385 droidlet.dldashboard -> droidlet.dashboard
* #384 droidlet.dlevent -> droidlet.event
* #383 move locobot/remote to lowlevel
* #382 move tests from locobot folder into droidlet folder
* #381 make locobot_agent work with this new directory structure
* #380 move locobot files into new directory structure

