### PR TITLE
change some base_agent references

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -16,9 +16,9 @@ ignore =
     W3, # blank line
     W5, # line break
 exclude =
-    ./base_agent/ttad/
-    ./base_agent/ttad/generation_dialogues/
-    ./base_agent/ttad/ttad_model/
-    ./base_agent/ttad-annotate/flows.py
+    ./droidlet/memory/ttad/
+    ./droidlet/memory/ttad/generation_dialogues/
+    ./droidlet/memory/ttad/ttad_model/
+    ./droidlet/memory/ttad-annotate/flows.py
     .git,
     __pycache__,

--- a/craftassist/test/validate_json.py
+++ b/craftassist/test/validate_json.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--schema_dir",
         type=str,
-        default="base_agent/documents/json_schema/",
+        default="droidlet/memory/documents/json_schema/",
         help="path to directory containing JSON schemas we want to load",
     )
     parser.add_argument(

--- a/docs/source/controller.md
+++ b/docs/source/controller.md
@@ -5,7 +5,7 @@
 
 In the "abstract" droidlet agent, the controller chooses whether to put Tasks on the Task Stack based on the memory state.   In the locobot agent and the craftassist agent subclasses, it consists of
 
-* a [DSL](https://github.com/fairinternal/minecraft/blob/master/base_agent/documents/Action_Dictionary_Spec.md)
+* a [DSL](https://github.com/facebookresearch/droidlet/blob/main/droidlet/memory/documents/Action_Dictionary_Spec.md)
 * a neural semantic parser, which translates natural language into partially specified programs over the DSL
 * a Dialogue Manager, Dialogue Stack, and Dialogue objects.
 * the Intepreter, a special Dialogue Object that takes partially specified programs from the DSL and fully specifies them using the Memory
@@ -14,7 +14,7 @@ In the "abstract" droidlet agent, the controller chooses whether to put Tasks on
 Dialogue Objects behave similarly to :ref:`tasks_label` , except they only affect the agent's environment directly by causing the agent to issue utterances (or indirectly by pushing Task Objects onto the Task Stack).  In particular, each Dialogue Object has a .step() that is run when it is the highest priority object on the Stack. Dialogue Objects, like Task Objects are modular:  a learned model or a heuristic can mediate the Dialogue Object, and the same model or heuristic script can be used across many different agents.
 ```
 
-The Dialogue Manager puts Dialogue Objects on the Dialogue Stack, either on its own, or at the request of a Dialogue Object.  In the locobot and craftassist agent, the manager is powered by a [neural semantic parser](https://github.com/fairinternal/minecraft/blob/master/base_agent/ttad/).
+The Dialogue Manager puts Dialogue Objects on the Dialogue Stack, either on its own, or at the request of a Dialogue Object.  In the locobot and craftassist agent, the manager is powered by a [neural semantic parser](https://github.com/facebookresearch/droidlet/blob/main/droidlet/dialog/ttad/).
 
 A sketch of the controller's operation is then
 ```
@@ -34,43 +34,43 @@ if TaskStack is empty:
 ## Dialogue Stack and Manager ##
 The Dialogue Stack holds Dialogue Objects, and steps them.
 ```eval_rst
- .. autoclass:: base_agent.dialogue_stack.DialogueStack
+ .. autoclass:: droidlet.dialog.dialogue_stack.DialogueStack
   :members: peek, clear, append, step
 ```
 The Dialogue Manager operates the Stack, and chooses whether to place Dialogue objects
 ```eval_rst
- .. autoclass:: base_agent.dialogue_manager.DialogueManager
+ .. autoclass:: droidlet.dialog.dialogue_manager.DialogueManager
   :members: step
 ```
 ### Semantic Parser ###
-The training of the semantic parsing model we use is described in detail [here](https://github.com/fairinternal/minecraft/tree/master/base_agent/ttad/); the interface is
+The training of the semantic parsing model we use is described in detail [here](https://github.com/facebookresearch/droidlet/tree/main/droidlet/dialog/ttad/); the interface is
 ```eval_rst
- .. autoclass:: base_agent.ttad.ttad_transformer_model.query_model.TTADBertModel
+ .. autoclass:: droidlet.dialog.ttad.ttad_transformer_model.query_model.TTADBertModel
   :members: parse
 ```
 ## Dialogue Objects ##
 The generic Dialogue Object is
 ```eval_rst
- .. autoclass:: base_agent.dialogue_objects.dialogue_object.DialogueObject
+ .. autoclass:: droidlet.dialog.dialogue_objects.dialogue_object.DialogueObject
    :members: step, check_finished
 ```
 A DialogueObject's main method is .step(),
 Some others:
 
 ```eval_rst
- .. autoclass:: base_agent.dialogue_objects.dialogue_object.Say
- .. autoclass:: base_agent.dialogue_objects.dialogue_object.AwaitResponse
- .. autoclass:: base_agent.dialogue_objects.dialogue_object.BotStackStatus
- .. autoclass:: base_agent.dialogue_objects.dialogue_object.ConfirmTask
- .. autoclass:: base_agent.dialogue_objects.dialogue_object.ConfirmReferenceObject
+ .. autoclass:: droidlet.dialog.dialogue_objects.dialogue_object.Say
+ .. autoclass:: droidlet.dialog.dialogue_objects.dialogue_object.AwaitResponse
+ .. autoclass:: droidlet.dialog.dialogue_objects.dialogue_object.BotStackStatus
+ .. autoclass:: droidlet.dialog.dialogue_objects.dialogue_object.ConfirmTask
+ .. autoclass:: droidlet.dialog.dialogue_objects.dialogue_object.ConfirmReferenceObject
 
 ```
 
 
 
 ### Interpreter ###
-The [Interpreter](https://github.com/fairinternal/minecraft/blob/master/base_agent/dialogue_objects/intepreter.py) is responsible for using the world state \(via [memory](memory.md)\) and a natural language utterance that has been parsed into a logical form over the agent's DSL from the semantic parser to choose a [Task](memory.md) to put on the Task Stack.   The [locobot](https://github.com/fairinternal/minecraft/blob/master/locobot/agent/dialogue_objects/loco_intepreter.py) and [craftassist](https://github.com/fairinternal/minecraft/blob/master/craftassist/agent/dialogue_objects/mc_intepreter.py) Interpreters are not the same, but the bulk of the work is done by the shared subinterpreters (in the files \*\_helper.py) [here](https://github.com/fairinternal/minecraft/blob/master/base_agent/dialogue_objects/).  The subinterpreters, registered in the main Interpreter [here](https://github.com/fairinternal/minecraft/blob/master/base_agent/dialogue_objects/intepreter.py#L55) \(and for the specialized versions [here](https://github.com/fairinternal/minecraft/blob/master/locobot/agent/dialogue_objects/loco_intepreter.py#L56) and [here](https://github.com/fairinternal/minecraft/blob/master/craftassist/agent/dialogue_objects/mc_intepreter.py#L61)\), roughly follow the structure of the DSL.  This arrangement is to allow replacing the (currently heuristic) subinterpreters with learned versions or specializing them to new agents.
+The [Interpreter](https://github.com/facebookresearch/droidlet/blob/main/droidlet/dialog/dialogue_objects/intepreter.py) is responsible for using the world state \(via [memory](memory.md)\) and a natural language utterance that has been parsed into a logical form over the agent's DSL from the semantic parser to choose a [Task](memory.md) to put on the Task Stack.   The [locobot](https://github.com/fairinternal/minecraft/blob/master/locobot/agent/dialogue_objects/loco_intepreter.py) and [craftassist](https://github.com/fairinternal/minecraft/blob/master/craftassist/agent/dialogue_objects/mc_intepreter.py) Interpreters are not the same, but the bulk of the work is done by the shared subinterpreters (in the files \*\_helper.py) [here](https://github.com/facebookresearch/droidlet/blob/main/droidlet/dialog/dialogue_objects/).  The subinterpreters, registered in the main Interpreter [here](https://github.com/facebookresearch/droidlet/blob/main/droidlet/dialog/dialogue_objects/intepreter.py#L55) \(and for the specialized versions [here](https://github.com/fairinternal/minecraft/blob/master/locobot/agent/dialogue_objects/loco_intepreter.py#L56) and [here](https://github.com/fairinternal/minecraft/blob/master/craftassist/agent/dialogue_objects/mc_intepreter.py#L61)\), roughly follow the structure of the DSL.  This arrangement is to allow replacing the (currently heuristic) subinterpreters with learned versions or specializing them to new agents.
 
 ```eval_rst
- .. autoclass:: base_agent.dialogue_objects.interpreter.Interpreter
+ .. autoclass:: droidlet.dialog.dialogue_objects.interpreter.Interpreter
 ```

--- a/docs/source/memory.md
+++ b/docs/source/memory.md
@@ -6,11 +6,11 @@ The memory system serves as the interface for passing information between the va
 
 ## Database #
 
-The entry point to the underlying SQL database is an [AgentMemory](https://github.com/fairinternal/minecraft/blob/master/base_agent/sql_memory.py) object.
-The database can be directly accessed by [\_db\_read\(query, \*args\)](https://github.com/fairinternal/minecraft/blob/master/base_agent/sql_memory.py#L719).  Some common queries using triples or that are otherwise unwieldy in raw SQL have been packaged in the [basic\_search\(search_data\)](https://github.com/fairinternal/minecraft/blob/master/base_agent/sql_memory.py#L227) [interface](https://github.com/fairinternal/minecraft/blob/master/base_agent/memory_filters.py#L214).
+The entry point to the underlying SQL database is an [AgentMemory](https://github.com/fairinternal/minecraft/blob/master/droidlet/memory/sql_memory.py) object.
+The database can be directly accessed by [\_db\_read\(query, \*args\)](https://github.com/fairinternal/minecraft/blob/master/droidlet/memory/sql_memory.py#L719).  Some common queries using triples or that are otherwise unwieldy in raw SQL have been packaged in the [basic\_search\(search_data\)](https://github.com/fairinternal/minecraft/blob/master/droidlet/memory/sql_memory.py#L227) [interface](https://github.com/fairinternal/minecraft/blob/master/droidlet/memory/memory_filters.py#L214).
 
 ```eval_rst
- .. autoclass:: base_agent.sql_memory.AgentMemory
+ .. autoclass:: droidlet.memory.sql_memory.AgentMemory
   :members:     basic_search, get_mem_by_id, forget, _db_read, _db_write, get_time, get_world_time, get_recent_entities, add_triple, tag, untag, get_memids_by_tag, get_tags_by_memid, get_triples, remove_memid_triple, task_stack_push, task_stack_update_task, task_stack_peek, task_stack_pop, task_stack_pause, task_stack_clear, task_stack_resume, task_stack_find_lowest_instance, task_stack_get_all, get_last_finished_root_task, get_task_by_id
 ```
 
@@ -19,15 +19,15 @@ MemoryNodes are python objects that collate data about a particular entity or ev
 
 
 ```eval_rst
-.. autoclass:: base_agent.memory_nodes.MemoryNode
-.. autoclass:: base_agent.memory_nodes.ProgramNode
-.. autoclass:: base_agent.memory_nodes.NamedAbstractionNode
-.. autoclass:: base_agent.memory_nodes.ReferenceObjectNode
-.. autoclass:: base_agent.memory_nodes.PlayerNode
-.. autoclass:: base_agent.memory_nodes.SelfNode
-.. autoclass:: base_agent.memory_nodes.LocationNode
-.. autoclass:: base_agent.memory_nodes.AttentionNode
-.. autoclass:: base_agent.memory_nodes.TimeNode
-.. autoclass:: base_agent.memory_nodes.ChatNode
-.. autoclass:: base_agent.memory_nodes.TaskNode
+.. autoclass:: droidlet.memory.memory_nodes.MemoryNode
+.. autoclass:: droidlet.memory.memory_nodes.ProgramNode
+.. autoclass:: droidlet.memory.memory_nodes.NamedAbstractionNode
+.. autoclass:: droidlet.memory.memory_nodes.ReferenceObjectNode
+.. autoclass:: droidlet.memory.memory_nodes.PlayerNode
+.. autoclass:: droidlet.memory.memory_nodes.SelfNode
+.. autoclass:: droidlet.memory.memory_nodes.LocationNode
+.. autoclass:: droidlet.memory.memory_nodes.AttentionNode
+.. autoclass:: droidlet.memory.memory_nodes.TimeNode
+.. autoclass:: droidlet.memory.memory_nodes.ChatNode
+.. autoclass:: droidlet.memory.memory_nodes.TaskNode
 ```

--- a/tools/codetools/autoformat_py_style.sh
+++ b/tools/codetools/autoformat_py_style.sh
@@ -6,4 +6,4 @@
 # cd to parent of script's directory (i.e. project root)
 cd "${0%/*}"/../..
 
-black base_agent craftassist droidlet
+black craftassist droidlet

--- a/tools/codetools/check_and_fix_black_failures.sh
+++ b/tools/codetools/check_and_fix_black_failures.sh
@@ -10,7 +10,7 @@ cd "${0%/*}"/../..
 
 echo '==== Black ====='
 
-CHECK_FILES="base_agent craftassist droidlet"
+CHECK_FILES="craftassist droidlet"
 
 black $CHECK_FILES
 

--- a/tools/codetools/check_flake8_failures.sh
+++ b/tools/codetools/check_flake8_failures.sh
@@ -47,5 +47,5 @@ if [[ $1 == "--ci" ]]; then
     fi
 else
     # run flake8 locally on all files
-    flake8 ./base_agent/
+    flake8 ./droidlet/
 fi

--- a/tools/data_scripts/try_download.sh
+++ b/tools/data_scripts/try_download.sh
@@ -12,7 +12,7 @@ ROOTDIR=$(pyabspath $(dirname "$0")/../../)
 echo "Rootdir ${ROOTDIR}"
 
 # Optionally fetch secure resources for internal users and prod systems
-python ${ROOTDIR}/tools/data_scripts/fetch_internal_resources.py ${ROOTDIR}/base_agent/documents/internal/
+python ${ROOTDIR}/tools/data_scripts/fetch_internal_resources.py ${ROOTDIR}/droidlet/memory/documents/internal/
 
 . ${ROOTDIR}/tools/data_scripts/checksum_fn.sh --source-only # import checksum function
 

--- a/tools/nsp_scripts/data_processing_scripts/remove_static_valid_commands.py
+++ b/tools/nsp_scripts/data_processing_scripts/remove_static_valid_commands.py
@@ -6,17 +6,17 @@ import argparse
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--data_source", default="base_agent/ttad/generation_dialogues/templated_pre.txt"
+        "--data_source", default="droidlet/dialog/ttad/generation_dialogues/templated_pre.txt"
     )
     parser.add_argument(
         "--commands_to_remove",
         help="path to test set commands to remove",
-        default="base_agent/ttad/generation_dialogues/templated_pre.txt",
+        default="droidlet/dialog/ttad/generation_dialogues/templated_pre.txt",
     )
     parser.add_argument(
         "--output_path",
         help="path of cleaned dataset to be used in train/valid split",
-        default="base_agent/ttad/generation_dialogues/templated_pre.txt",
+        default="droidlet/dialog/ttad/generation_dialogues/templated_pre.txt",
     )
     opts = parser.parse_args()
     with open(opts.commands_to_remove) as fd:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #410 improve craftassist makefiles
* #409 add cmake modules to find glog and gflags
* #408 move locobot's perception into a robot/ folder temporarily
* #407 fix pytest path in craftassist/test/test.sh
* #405 fix circleci base_agent tests path
* #395 move more files from craftassist to droidlet/*
* #394 move minecraft_specs -> specs
* #392 move some craftassist files into droidlet
* #391 fix craftassist tests
* #390 small fix in locobot after rebase
* #389 fix circleci tests
* **#396 change some base_agent references**
* #388 fix craftassist tests after base_agent move
* #387 fixes after base_agent move
* #386 move droidlet/*/* into a droidlet/*/robot/* subfolder, and move base_agent files into their appropriate droidlet/ subfolder equivalents
* #385 droidlet.dldashboard -> droidlet.dashboard
* #384 droidlet.dlevent -> droidlet.event
* #383 move locobot/remote to lowlevel
* #382 move tests from locobot folder into droidlet folder
* #381 make locobot_agent work with this new directory structure
* #380 move locobot files into new directory structure

