### PR TITLE
catch unknown blocks in find holes

### DIFF
--- a/craftassist/agent/heuristic_perception.py
+++ b/craftassist/agent/heuristic_perception.py
@@ -509,15 +509,20 @@ def get_all_nearby_holes(agent, location, radius=15, store_inst_seg=True):
     hole_mems = []
     for hole in holes:
         memid = InstSegNode.create(agent.memory, hole[0], tags=["hole", "pit", "mine"])
-        fill_block_name = BLOCK_DATA["bid_to_name"][hole[1]]
-        fill_block_mems = agent.memory.basic_search(
-            {
-                "base_table": "BlockTypes",
-                "triples": [{"pred_text": "has_name", "obj_text": fill_block_name}],
-            }
-        )
-        fill_block_memid = fill_block_mems[0].memid
-        agent.memory.add_triple(subj=memid, pred_text="has_fill_type", obj=fill_block_memid)
+        try:
+            fill_block_name = BLOCK_DATA["bid_to_name"][hole[1]]
+        except:
+            idm = (hole[1][0], 0)
+            fill_block_name = BLOCK_DATA["bid_to_name"].get(idm)
+        if fill_block_name:
+            fill_block_mems = agent.memory.basic_search(
+                {
+                    "base_table": "BlockTypes",
+                    "triples": [{"pred_text": "has_name", "obj_text": fill_block_name}],
+                }
+            )
+            fill_block_memid = fill_block_mems[0].memid
+            agent.memory.add_triple(subj=memid, pred_text="has_fill_type", obj=fill_block_memid)
         hole_mems.append(agent.memory.get_mem_by_id(memid))
     return hole_mems
 


### PR DESCRIPTION
# Description

catch unknown (e.g. not in BLOCK_DATA["bid_to_name"]) blocks when finding fill type for holes.  
first, try to find the base idm, if still can't find, don't remember the fill type (so will fill with dirt if a fill task is placed)

Fixes # (issue)

https://github.com/facebookresearch/droidlet/issues/377

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.


# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

