### PR TITLE
[Bugfix] Fix safety checks failure by adding base_agent/documents/internal/ to version control

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ jobs:
             echo ${AWS_S3_ACCESS_KEY_ID} > tools/docker/AWS_S3_ACCESS_KEY_ID.txt
             echo ${AWS_S3_SECRET_ACCESS_KEY} > tools/docker/AWS_S3_SECRET_ACCESS_KEY.txt
 
+      - run:
+          name: Python style checks (black and awscli)
+          command: |
+            pip3 install boto3
+
       - setup_remote_docker
       - run:
           name: Build docker containers

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ __pycache__
 *.sql
 !memory_schema.sql
 *~
-base_agent/documents/internal/*
+base_agent/documents/internal/*.txt
 bin/*
 writeups/*.pdf
 writeups/*.aux

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -11,10 +11,11 @@ ENV GIT_SSH_COMMAND "ssh -i /mcdeploy.key -o StrictHostKeyChecking=no"
 RUN git clone --recursive git@github.com:facebookresearch/droidlet.git
 WORKDIR droidlet
 RUN git checkout ${current_branch}
-RUN tools/data_scripts/try_download.sh craftassist
 
 RUN pip3 install -r requirements.txt
 RUN pip3 install -U setuptools
+
+RUN tools/data_scripts/try_download.sh craftassist
 
 RUN mkdir -p /cache/.ccache
 RUN (AWS_ACCESS_KEY_ID=$(cat /AWS_S3_ACCESS_KEY_ID.txt) AWS_SECRET_ACCESS_KEY=$(cat /AWS_S3_SECRET_ACCESS_KEY.txt) curl http://craftassist.s3-us-west-2.amazonaws.com/pubr/client_ccache.tar.gz -o /client_ccache.tar.gz -f && tar -xvf /client_ccache.tar.gz -C /cache) || echo "Pulling ccache from S3"


### PR DESCRIPTION
# Description

Fixes safety test failures caused by adding auth to downloading protected resources. 

The cause for failure is that `safety.txt` was not downloaded to the right place, because `base_agent/documents/internal/` was not tracked as a directory. Git does not track empty directories, and `base_agent/documents/internal/*` path was under our `.gitignore`. To fix, I added a `.gitkeep` and the internal folder to version control.

Fixes # (issue)

#243 #311 (note CI was passing due to bug introduced in previous commits) 

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.