### PR TITLE
fix circleci base_agent tests path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           name: Base Agent Python unit tests
           command: |
               mkdir shared
-              docker run --name base-tests -v $(pwd):/shared -w /droidlet --entrypoint="/bin/bash" craftassist -c "python3 setup.py develop && cd /shared && pytest --cov-report=xml:$SHARED_PATH/test_base.xml --cov=$COV_RELATIVE droidlet/memory/tests/ --disable-pytest-warnings"
+              docker run --name base-tests -v $(pwd):/shared -w /droidlet --entrypoint="/bin/bash" craftassist -c "python3 setup.py develop && cd /shared && pytest --cov-report=xml:$SHARED_PATH/test_base.xml --cov=$COV_RELATIVE /droidlet/memory/tests/ --disable-pytest-warnings"
               docker cp base-tests:/shared shared
               pip3 install codecov
               CODECOV_TOKEN='6cff57e1-08ce-4d98-8f28-63797d90107f'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           name: Base Agent Python unit tests
           command: |
               mkdir shared
-              docker run --name base-tests -v $(pwd):/shared -w /droidlet --entrypoint="/bin/bash" craftassist -c "python3 setup.py develop && cd /shared && pytest --cov-report=xml:$SHARED_PATH/test_base.xml --cov=$COV_RELATIVE /droidlet/memory/tests/ --disable-pytest-warnings"
+              docker run --name base-tests -v $(pwd):/shared -w /droidlet --entrypoint="/bin/bash" craftassist -c "python3 setup.py develop && cd /shared && pytest --cov-report=xml:$SHARED_PATH/test_base.xml --cov=$COV_RELATIVE /droidlet/droidlet/memory/tests/ --disable-pytest-warnings"
               docker cp base-tests:/shared shared
               pip3 install codecov
               CODECOV_TOKEN='6cff57e1-08ce-4d98-8f28-63797d90107f'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #410 improve craftassist makefiles
* #409 add cmake modules to find glog and gflags
* #408 move locobot's perception into a robot/ folder temporarily
* #407 fix pytest path in craftassist/test/test.sh
* **#405 fix circleci base_agent tests path**
* #395 move more files from craftassist to droidlet/*
* #394 move minecraft_specs -> specs
* #392 move some craftassist files into droidlet
* #391 fix craftassist tests
* #390 small fix in locobot after rebase
* #389 fix circleci tests
* #396 change some base_agent references
* #388 fix craftassist tests after base_agent move
* #387 fixes after base_agent move
* #386 move droidlet/*/* into a droidlet/*/robot/* subfolder, and move base_agent files into their appropriate droidlet/ subfolder equivalents
* #385 droidlet.dldashboard -> droidlet.dashboard
* #384 droidlet.dlevent -> droidlet.event
* #383 move locobot/remote to lowlevel
* #382 move tests from locobot folder into droidlet folder
* #381 make locobot_agent work with this new directory structure
* #380 move locobot files into new directory structure

