### PR TITLE
fix pytest path in craftassist/test/test.sh

### DIFF
--- a/craftassist/test/test.sh
+++ b/craftassist/test/test.sh
@@ -8,6 +8,6 @@ cd $(dirname $0)
 SHARED_PATH=/shared
 COV_RELATIVE=craftassist
 
-pytest --cov-report=xml:$SHARED_PATH/test_MC.xml --cov=$COV_RELATIVE craftassist/test/ --disable-pytest-warnings
+pytest --cov-report=xml:$SHARED_PATH/test_MC.xml --cov=$COV_RELATIVE . --disable-pytest-warnings
 status=$?
 exit $status


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #410 improve craftassist makefiles
* #409 add cmake modules to find glog and gflags
* #408 move locobot's perception into a robot/ folder temporarily
* **#407 fix pytest path in craftassist/test/test.sh**
* #405 fix circleci base_agent tests path
* #395 move more files from craftassist to droidlet/*
* #394 move minecraft_specs -> specs
* #392 move some craftassist files into droidlet
* #391 fix craftassist tests
* #390 small fix in locobot after rebase
* #389 fix circleci tests
* #396 change some base_agent references
* #388 fix craftassist tests after base_agent move
* #387 fixes after base_agent move
* #386 move droidlet/*/* into a droidlet/*/robot/* subfolder, and move base_agent files into their appropriate droidlet/ subfolder equivalents
* #385 droidlet.dldashboard -> droidlet.dashboard
* #384 droidlet.dlevent -> droidlet.event
* #383 move locobot/remote to lowlevel
* #382 move tests from locobot folder into droidlet folder
* #381 make locobot_agent work with this new directory structure
* #380 move locobot files into new directory structure

