### PR TITLE
improve craftassist makefiles

### DIFF
--- a/craftassist/Makefile
+++ b/craftassist/Makefile
@@ -2,10 +2,19 @@ SHELL=/bin/bash
 
 .PHONY: cuberite clang-format client log_render schematic_convert render_view
 
+CC?=gcc
+CXX?=g++
 COMMON_CLIENT_CPP=client/src/block_map.cpp client/src/game_state.cpp client/src/graphics.cpp client/src/packet_writer.cpp client/src/types.cpp client/src/util.cpp client/src/nbt_tag.cpp
 COMMON_LOGGING_CPP=logging/src/anvil_reader.cpp logging/src/logging_reader.cpp
 COMPILE_FLAGS=-std=c++17 -Wall -Wextra -Werror -O3
 LINK_FLAGS=-lglog -lgflags -lz -pthread
+ifeq ($(CMAKE_PREFIX_PATH),)
+INCLUDE_FLAGS:=
+LIBDIR_FLAGS:=
+else
+INCLUDE_FLAGS:=-I $(CMAKE_PREFIX_PATH)/include
+LIBDIR_FLAGS:=-L $(CMAKE_PREFIX_PATH)/lib
+endif
 
 BIN=bin/log_render bin/render_view bin/schematic_convert
 CUBERITE_MAKEFILE=cuberite/Makefile
@@ -24,23 +33,26 @@ client:
 	make
 
 log_render:
-	g++ ${COMPILE_FLAGS} \
+	${CXX} ${COMPILE_FLAGS} \
+		${INCLUDE_FLAGS} ${LIBDIR_FLAGS} \
 		${COMMON_CLIENT_CPP} ${COMMON_LOGGING_CPP} logging/src/log_render.cpp \
 		-o bin/log_render \
-		${LINK_FLAGS}
+		${LINK_FLAGS} -Wno-sign-compare -Wno-deprecated-copy
 
 render_view:
-	g++ ${COMPILE_FLAGS} \
+	${CXX} ${COMPILE_FLAGS} \
+		${INCLUDE_FLAGS} ${LIBDIR_FLAGS} \
 		${COMMON_CLIENT_CPP} ${COMMON_LOGGING_CPP} logging/src/render_view.cpp \
 		-o bin/render_view \
-		${LINK_FLAGS}
+		${LINK_FLAGS} -Wno-sign-compare -Wno-deprecated-copy
 
 schematic_convert:
-	g++ ${COMPILE_FLAGS} \
+	${CXX} ${COMPILE_FLAGS} \
+		${INCLUDE_FLAGS} ${LIBDIR_FLAGS} \
 		${COMMON_CLIENT_CPP} \
 		schematic_convert/src/schematic_convert.cpp \
 		-o bin/schematic_convert \
-		${LINK_FLAGS}
+		${LINK_FLAGS} -Wno-sign-compare -Wno-deprecated-copy
 
 clang-format:
 	bin/clang-format

--- a/craftassist/client/CMakeLists.txt
+++ b/craftassist/client/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required (VERSION 2.8)
-set(CMAKE_CXX_COMPILER "g++")
+cmake_minimum_required (VERSION 3.0)
 project (minecraft_client)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/Modules)
 
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)
@@ -8,22 +9,25 @@ if(CCACHE_FOUND)
 	set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
-find_library(glog REQUIRED)
-find_library(gflags REQUIRED)
-find_library(z REQUIRED)
-find_library(Boost REQUIRED)
+find_package(glog REQUIRED)
+find_package(gflags REQUIRED)
+find_library(LIBZ_LIBRARY z REQUIRED)
+find_package(Boost REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "bin")
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -Werror -O3")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -O3")
 
-set(LINKS gflags glog z)
+
+include_directories(${GLOG_INCLUDE_DIR})
+include_directories(${GFLAGS_INCLUDE_DIR})
 file(GLOB SOURCES "src/*.cpp")
 
 add_subdirectory(pybind11)
 pybind11_add_module(mc_agent ${SOURCES})
-target_link_libraries(mc_agent ${LINKS})
+target_link_libraries(mc_agent PUBLIC ${GFLAGS_LIBRARY} ${GLOG_LIBRARY} ${LIBZ_LIBRARY})
 set_target_properties(mc_agent PROPERTIES OUTPUT_NAME ../../droidlet/lowlevel/minecraft/mc_agent)
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLASG} -Wno-sign-compare -Wno-deprecated-copy")
 
 add_custom_target(run
 	COMMAND python agent/mc_agent.py


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#410 improve craftassist makefiles**
* #409 add cmake modules to find glog and gflags
* #408 move locobot's perception into a robot/ folder temporarily
* #407 fix pytest path in craftassist/test/test.sh
* #405 fix circleci base_agent tests path
* #395 move more files from craftassist to droidlet/*
* #394 move minecraft_specs -> specs
* #392 move some craftassist files into droidlet
* #391 fix craftassist tests
* #390 small fix in locobot after rebase
* #389 fix circleci tests
* #396 change some base_agent references
* #388 fix craftassist tests after base_agent move
* #387 fixes after base_agent move
* #386 move droidlet/*/* into a droidlet/*/robot/* subfolder, and move base_agent files into their appropriate droidlet/ subfolder equivalents
* #385 droidlet.dldashboard -> droidlet.dashboard
* #384 droidlet.dlevent -> droidlet.event
* #383 move locobot/remote to lowlevel
* #382 move tests from locobot folder into droidlet folder
* #381 make locobot_agent work with this new directory structure
* #380 move locobot files into new directory structure

