### PR TITLE
remove redefinition of heuristic hole finder in test with mock

### DIFF
--- a/craftassist/test/test_interpreter.py
+++ b/craftassist/test/test_interpreter.py
@@ -27,7 +27,7 @@ def add_two_cubes(test):
     test.set_looking_at(test.cube_right[0][0])
 
 
-class TwoCubesInterpreterTest(BaseCraftassistTestCase):
+class ATwoCubesInterpreterTest(BaseCraftassistTestCase):
     """A basic general-purpose test suite in a world which begins with two cubes.
 
     N.B. by default, the agent is looking at cube_right
@@ -102,11 +102,6 @@ class TwoCubesInterpreterTest(BaseCraftassistTestCase):
         # check that a Build was added with a gold blocks
         self.assertGreater(len(changes), 0)
         self.assertEqual(set(changes.values()), set([(41, 0)]))
-
-    def test_fill_all_holes_no_holes(self):
-        d = FILL_COMMANDS["fill all holes where I am looking"]
-        heuristic_perception.get_all_nearby_holes = Mock(return_value=[])  # no holes
-        self.handle_logical_form(d)
 
     def test_go_to_the_tree(self):
         d = MOVE_COMMANDS["go to the tree"]
@@ -346,6 +341,11 @@ class FillTest(BaseCraftassistTestCase):
 
         # Make sure hole is filled with gold
         self.assertEqual(set(self.get_idm_at_locs(self.hole_poss).values()), set([(41, 0)]))
+
+    def test_fill_all_holes_no_holes(self):
+        self.set_blocks([(pos, (3, 0)) for pos in self.hole_poss])
+        d = FILL_COMMANDS["fill all holes where I am looking"]
+        self.handle_logical_form(d)
 
 
 if __name__ == "__main__":

--- a/craftassist/test/test_interpreter.py
+++ b/craftassist/test/test_interpreter.py
@@ -27,7 +27,7 @@ def add_two_cubes(test):
     test.set_looking_at(test.cube_right[0][0])
 
 
-class ATwoCubesInterpreterTest(BaseCraftassistTestCase):
+class TwoCubesInterpreterTest(BaseCraftassistTestCase):
     """A basic general-purpose test suite in a world which begins with two cubes.
 
     N.B. by default, the agent is looking at cube_right


### PR DESCRIPTION
# Description

It was discovered that the order of tests in craftassist has a bearing on their success; in particular FillTest.  This was due to a test redefining the heuristic perception method finding holes

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

The offending test is moved from TwoCubesTest to FillTest, and instead of redefining the heuristic we just make sure there ar no holes for the particular test where the heuristic was supposed to not find holes. 

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

