### PR TITLE
Fixing CCache, compatibility with $CC, $CXX, improving speed of circleci builds, improve gflags/glog detection in cmake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,6 @@ jobs:
             echo 'export DOCKER_BUILD_ARGS="--build-arg current_branch=${CIRCLE_BRANCH} --build-arg AWS_ACCESS_KEY_ID=${AWS_S3_ACCESS_KEY_ID} --build-arg AWS_SECRET_ACCESS_KEY=${AWS_S3_SECRET_ACCESS_KEY}"' >> $BASH_ENV
 
       - run:
-          name: Deploy Github key
-          command: |
-            echo ${MCDEPLOY_KEY_B64} | base64 -d > tools/docker/mcdeploy.key
-            chmod 400 tools/docker/mcdeploy.key
-
-      - setup_remote_docker
-      - run:
           name: Build docker containers
           command: make -C tools/docker build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,15 @@
 version: 2.1
 jobs:
   minecraft:
-    docker:
-      - image: ubuntu:18.04
+    machine:
+      image: ubuntu-2004:202104-01
+    resource_class: xlarge
     steps:
       - run:
           name: Install dependencies
           command: |
-            apt update
-            apt install -y git python3 python3-pip apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-            apt-key fingerprint 0EBFCD88
-            add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-            apt update
-            apt install -y docker-ce docker-ce-cli containerd.io
+            sudo apt update
+            sudo apt install -y git python3 python3-pip apt-transport-https ca-certificates curl gnupg-agent software-properties-common
       - checkout
 
       - run:

--- a/craftassist/Makefile
+++ b/craftassist/Makefile
@@ -2,10 +2,19 @@ SHELL=/bin/bash
 
 .PHONY: cuberite clang-format client log_render schematic_convert render_view
 
+CC?=gcc
+CXX?=g++
 COMMON_CLIENT_CPP=client/src/block_map.cpp client/src/game_state.cpp client/src/graphics.cpp client/src/packet_writer.cpp client/src/types.cpp client/src/util.cpp client/src/nbt_tag.cpp
 COMMON_LOGGING_CPP=logging/src/anvil_reader.cpp logging/src/logging_reader.cpp
 COMPILE_FLAGS=-std=c++17 -Wall -Wextra -Werror -O3
 LINK_FLAGS=-lglog -lgflags -lz -pthread
+ifeq ($(CMAKE_PREFIX_PATH),)
+INCLUDE_FLAGS:=
+LIBDIR_FLAGS:=
+else
+INCLUDE_FLAGS:=-I $(CMAKE_PREFIX_PATH)/include
+LIBDIR_FLAGS:=-L $(CMAKE_PREFIX_PATH)/lib
+endif
 
 BIN=bin/log_render bin/render_view bin/schematic_convert
 CUBERITE_MAKEFILE=cuberite/Makefile
@@ -24,23 +33,26 @@ client:
 	make
 
 log_render:
-	g++ ${COMPILE_FLAGS} \
+	${CXX} ${COMPILE_FLAGS} \
+		${INCLUDE_FLAGS} ${LIBDIR_FLAGS} \
 		${COMMON_CLIENT_CPP} ${COMMON_LOGGING_CPP} logging/src/log_render.cpp \
 		-o bin/log_render \
-		${LINK_FLAGS}
+		${LINK_FLAGS} -Wno-sign-compare -Wno-deprecated-copy
 
 render_view:
-	g++ ${COMPILE_FLAGS} \
+	${CXX} ${COMPILE_FLAGS} \
+		${INCLUDE_FLAGS} ${LIBDIR_FLAGS} \
 		${COMMON_CLIENT_CPP} ${COMMON_LOGGING_CPP} logging/src/render_view.cpp \
 		-o bin/render_view \
-		${LINK_FLAGS}
+		${LINK_FLAGS} -Wno-sign-compare -Wno-deprecated-copy
 
 schematic_convert:
-	g++ ${COMPILE_FLAGS} \
+	${CXX} ${COMPILE_FLAGS} \
+		${INCLUDE_FLAGS} ${LIBDIR_FLAGS} \
 		${COMMON_CLIENT_CPP} \
 		schematic_convert/src/schematic_convert.cpp \
 		-o bin/schematic_convert \
-		${LINK_FLAGS}
+		${LINK_FLAGS} -Wno-sign-compare -Wno-deprecated-copy
 
 clang-format:
 	bin/clang-format

--- a/craftassist/client/CMakeLists.txt
+++ b/craftassist/client/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required (VERSION 2.8)
-set(CMAKE_CXX_COMPILER "g++")
+cmake_minimum_required (VERSION 3.0)
 project (minecraft_client)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/Modules)
 
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)
@@ -8,22 +9,25 @@ if(CCACHE_FOUND)
 	set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
-find_library(glog REQUIRED)
-find_library(gflags REQUIRED)
-find_library(z REQUIRED)
-find_library(Boost REQUIRED)
+find_package(glog REQUIRED)
+find_package(gflags REQUIRED)
+find_library(LIBZ_LIBRARY z REQUIRED)
+find_package(Boost REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "bin")
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -Werror -O3")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -O3")
 
-set(LINKS gflags glog z)
+
+include_directories(${GLOG_INCLUDE_DIR})
+include_directories(${GFLAGS_INCLUDE_DIR})
 file(GLOB SOURCES "src/*.cpp")
 
 add_subdirectory(pybind11)
 pybind11_add_module(mc_agent ${SOURCES})
-target_link_libraries(mc_agent ${LINKS})
+target_link_libraries(mc_agent PUBLIC ${GFLAGS_LIBRARY} ${GLOG_LIBRARY} ${LIBZ_LIBRARY})
 set_target_properties(mc_agent PROPERTIES OUTPUT_NAME ../agent/mc_agent)
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLASG} -Wno-sign-compare -Wno-deprecated-copy")
 
 add_custom_target(run
 	COMMAND python agent/mc_agent.py

--- a/craftassist/client/cmake/Modules/Findgflags.cmake
+++ b/craftassist/client/cmake/Modules/Findgflags.cmake
@@ -1,0 +1,50 @@
+# - Try to find GFLAGS
+#
+# The following variables are optionally searched for defaults
+#  GFLAGS_ROOT_DIR:            Base directory where all GFLAGS components are found
+#
+# The following are set after configuration is done:
+#  GFLAGS_FOUND
+#  GFLAGS_INCLUDE_DIRS
+#  GFLAGS_LIBRARIES
+#  GFLAGS_LIBRARYRARY_DIRS
+
+include(FindPackageHandleStandardArgs)
+
+set(GFLAGS_ROOT_DIR "" CACHE PATH "Folder contains Gflags")
+
+# We are testing only a couple of files in the include directories
+if(WIN32)
+    find_path(GFLAGS_INCLUDE_DIR gflags/gflags.h
+        PATHS ${GFLAGS_ROOT_DIR}/src/windows)
+else()
+    find_path(GFLAGS_INCLUDE_DIR gflags/gflags.h
+        PATHS ${GFLAGS_ROOT_DIR})
+endif()
+
+if(MSVC)
+    find_library(GFLAGS_LIBRARY_RELEASE
+        NAMES libgflags
+        PATHS ${GFLAGS_ROOT_DIR}
+        PATH_SUFFIXES Release)
+
+    find_library(GFLAGS_LIBRARY_DEBUG
+        NAMES libgflags-debug
+        PATHS ${GFLAGS_ROOT_DIR}
+        PATH_SUFFIXES Debug)
+
+    set(GFLAGS_LIBRARY optimized ${GFLAGS_LIBRARY_RELEASE} debug ${GFLAGS_LIBRARY_DEBUG})
+else()
+    find_library(GFLAGS_LIBRARY gflags)
+endif()
+
+find_package_handle_standard_args(gflags DEFAULT_MSG GFLAGS_INCLUDE_DIR GFLAGS_LIBRARY)
+
+
+if(GFLAGS_FOUND)
+    set(GFLAGS_INCLUDE_DIRS ${GFLAGS_INCLUDE_DIR})
+    set(GFLAGS_LIBRARIES ${GFLAGS_LIBRARY})
+    message(STATUS "Found gflags  (include: ${GFLAGS_INCLUDE_DIR}, library: ${GFLAGS_LIBRARY})")
+    mark_as_advanced(GFLAGS_LIBRARY_DEBUG GFLAGS_LIBRARY_RELEASE
+                     GFLAGS_LIBRARY GFLAGS_INCLUDE_DIR GFLAGS_ROOT_DIR)
+endif()

--- a/craftassist/client/cmake/Modules/Findglog.cmake
+++ b/craftassist/client/cmake/Modules/Findglog.cmake
@@ -1,0 +1,48 @@
+# - Try to find Glog
+#
+# The following variables are optionally searched for defaults
+#  GLOG_ROOT_DIR:            Base directory where all GLOG components are found
+#
+# The following are set after configuration is done:
+#  GLOG_FOUND
+#  GLOG_INCLUDE_DIRS
+#  GLOG_LIBRARIES
+#  GLOG_LIBRARYRARY_DIRS
+
+include(FindPackageHandleStandardArgs)
+
+set(GLOG_ROOT_DIR "" CACHE PATH "Folder contains Google glog")
+
+if(WIN32)
+    find_path(GLOG_INCLUDE_DIR glog/logging.h
+        PATHS ${GLOG_ROOT_DIR}/src/windows)
+else()
+    find_path(GLOG_INCLUDE_DIR glog/logging.h
+        PATHS ${GLOG_ROOT_DIR})
+endif()
+
+if(MSVC)
+    find_library(GLOG_LIBRARY_RELEASE libglog_static
+        PATHS ${GLOG_ROOT_DIR}
+        PATH_SUFFIXES Release)
+
+    find_library(GLOG_LIBRARY_DEBUG libglog_static
+        PATHS ${GLOG_ROOT_DIR}
+        PATH_SUFFIXES Debug)
+
+    set(GLOG_LIBRARY optimized ${GLOG_LIBRARY_RELEASE} debug ${GLOG_LIBRARY_DEBUG})
+else()
+    find_library(GLOG_LIBRARY glog
+        PATHS ${GLOG_ROOT_DIR}
+        PATH_SUFFIXES lib lib64)
+endif()
+
+find_package_handle_standard_args(glog DEFAULT_MSG GLOG_INCLUDE_DIR GLOG_LIBRARY)
+
+if(GLOG_FOUND)
+  set(GLOG_INCLUDE_DIRS ${GLOG_INCLUDE_DIR})
+  set(GLOG_LIBRARIES ${GLOG_LIBRARY})
+  message(STATUS "Found glog    (include: ${GLOG_INCLUDE_DIR}, library: ${GLOG_LIBRARY})")
+  mark_as_advanced(GLOG_ROOT_DIR GLOG_LIBRARY_RELEASE GLOG_LIBRARY_DEBUG
+                                 GLOG_LIBRARY GLOG_INCLUDE_DIR)
+endif()

--- a/tools/data_scripts/fetch_aws_datasets.sh
+++ b/tools/data_scripts/fetch_aws_datasets.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 function pyabspath() {
-    python -c "import os; import sys; print(os.path.realpath(sys.argv[1]))" $1
+    python3 -c "import os; import sys; print(os.path.realpath(sys.argv[1]))" $1
 }
 
 ROOTDIR=$(pyabspath $(dirname "$0")/../../)

--- a/tools/data_scripts/fetch_aws_models.sh
+++ b/tools/data_scripts/fetch_aws_models.sh
@@ -3,7 +3,7 @@
 
 
 function pyabspath() {
-    python -c "import os; import sys; print(os.path.realpath(sys.argv[1]))" $1
+    python3 -c "import os; import sys; print(os.path.realpath(sys.argv[1]))" $1
 }
 
 ROOTDIR=$(pyabspath $(dirname "$0")/../../)

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,29 +1,35 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 FROM shaomai/craftassist:latest as base
 
-COPY mcdeploy.key /mcdeploy.key
 ARG current_branch
-
-# Clone/make repo
-ENV GIT_SSH_COMMAND "ssh -i /mcdeploy.key -o StrictHostKeyChecking=no"
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY
 
-RUN git clone --recursive git@github.com:facebookresearch/droidlet.git
+
+# Clone/make repo
+RUN git clone --recursive -b ${current_branch} https://github.com/facebookresearch/droidlet
 WORKDIR droidlet
-RUN git checkout ${current_branch}
 
 RUN pip3 install -r requirements.txt
-RUN pip3 install -U setuptools
+
 RUN tools/data_scripts/try_download.sh craftassist
 
-RUN mkdir -p /cache/.ccache
-RUN (curl http://craftassist.s3-us-west-2.amazonaws.com/pubr/client_ccache.tar.gz -o /client_ccache.tar.gz -f && tar -xvf /client_ccache.tar.gz -C /cache) || echo "Pulling ccache from S3"
-RUN export CCACHE_DIR="/cache/.ccache"
-RUN git submodule update --init --recursive
-RUN cd craftassist && make && cd ..
-RUN tar -cvzf client_ccache.tar.gz /cache/.ccache
-RUN aws s3 cp client_ccache.tar.gz s3://craftassist/pubr/client_ccache.tar.gz
+
+RUN ((curl http://craftassist.s3-us-west-2.amazonaws.com/pubr/client_ccache.tar.gz -o /client_ccache.tar.gz -f && \
+      tar -xvf /client_ccache.tar.gz -C /cache/.ccache) \
+      || echo "Failed pulling ccache from S3") && \
+    ccache -s && \
+    ls -alh /client_ccache.tar.gz && \
+    ls -alh /cache/.ccache && \
+    cd craftassist && \
+    CC="/usr/local/bin/gcc" CXX="/usr/local/bin/g++" make && \
+    cd .. && \
+    tar -cvzf client_ccache.tar.gz -C /cache/.ccache . && \
+    ls -alh client_ccache.tar.gz && \
+    aws s3 cp client_ccache.tar.gz s3://craftassist/pubr/client_ccache.tar.gz --acl public-read && \
+    ls -alh /cache/.ccache && \
+    ccache -s && \
+    rm -rf client_ccache.tar.gz /cache/.ccache /client_ccache.tar.gz
 
 RUN npm install -g yarn
 RUN cd /droidlet/dldashboard/web && yarn install

--- a/tools/docker/Dockerfile.base
+++ b/tools/docker/Dockerfile.base
@@ -1,11 +1,14 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This is pre-built and is imported in ./Dockerfile as base
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get -y update
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata && \
+    ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
+    dpkg-reconfigure --frontend noninteractive tzdata
 RUN apt-get install -y \
-        cmake \
 	curl \
+	lld \
         g++ \
         clang-format \
         git \
@@ -20,6 +23,8 @@ RUN apt-get install -y \
         zlib1g-dev \
         ;
 
+RUN pip3 install -U setuptools cmake
+
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
 RUN apt-get -y install nodejs
 
@@ -33,3 +38,23 @@ RUN add-apt-repository ppa:git-core/ppa \
         && bash /gitlfs_install.sh \
         && apt-get install -y git-lfs \
         && git lfs install
+
+
+# get latest ccache instead of system-packaged one
+RUN apt remove -y ccache
+RUN apt install -y libzstd-dev
+RUN cd /tmp && curl -L https://github.com/ccache/ccache/releases/download/v4.3/ccache-4.3.tar.gz -o ccache-4.3.tar.gz && \
+    tar -xvf ccache-4.3.tar.gz && \
+    cd ccache-4.3 && \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    make && \
+    make install && \
+    ln -s ccache /usr/local/bin/gcc && \
+    ln -s ccache /usr/local/bin/g++ && \
+    ln -s ccache /usr/local/bin/cc && \
+    ln -s ccache /usr/local/bin/c++
+ENV PATH "/usr/local/bin:$PATH"
+ENV CCACHE_DIR "/cache/.ccache"
+RUN mkdir -p /cache/.ccache


### PR DESCRIPTION
# Description

There are a few commits, all related to CI / build system.

#### Feature set 1
improve craftassist makefiles by adding $CC / $CXX compatibility, and also make glog/gflags detection more robust

#### Feature set 2
    move minecraft testing base from a circleci docker instance to machine image instance.

    This was done because a circleci docker inside a docker (how the tests were running) has a few limitations, including

    1. only exposing 2 CPUs in the 2nd docker regardless of the actual range of available CPUs
    2. only exposing 8GB of memory regardless of the parent resource class
    3. kernel restrictions that didn't allow one to run any stack sampling tools (such as `perf top` or `py-spy`) in the circleci job via ssh

#### Feature  set 3

    Gets ccache working, fixing 4 different bugs:

    1. this kinda never worked curl http://craftassist.s3-us-west-2.amazonaws.com/pubr/client_ccache.tar.gz because this command aws s3 cp client_ccache.tar.gz s3://craftassist/pubr/client_ccache.tar.gz does not actually make the file public. I had to add the --acl public-read to that command
    2. this RUN export CCACHE_DIR="/cache/.ccache" does not work in the sense that export in a Dockerfile is only alive for the lifetime of the command. So, when the next line in the Dockerfile runs, there is no CCACHE_DIR in the environment variables
    3. the ccache compiler paths are never set, doing which gcc or which g++ still returns /usr/bin/gcc and /usr/bin/g++, so basically ccache is never even entering the picture
    4. The tar extraction of the downloaded ccache was going into `/cache/cache/.ccache` because the `tar cvfz` missed a directory switching `-C` option.

Additionally, upgrades the base craftassist image to Ubuntu 20.04 for improved tooling (for example upgraded `lld` package)

#### Feature  set 4

Removes `mcdeploy.key` in the docker images, which is no longer needed as droidlet is now a public repository