### PR TITLE
[Dashboard][Turk] Add instructions for error marking

### DIFF
--- a/crowdsourcing/droidlet_static_html_task/server_files/craftassist_task.html
+++ b/crowdsourcing/droidlet_static_html_task/server_files/craftassist_task.html
@@ -79,17 +79,17 @@
             </b></p>
 
             <h3>How to enter voxel world and control</h3>
-            <p>Please click on the bottom-left pane to enter the 3-D voxel world.<br />
+            <p>Please click on the upper right pane to enter the 3-D voxel world.<br />
             <b>Please use ‘w/a/s/d’ to move ‘forward/left/back/right’ , ‘space’ to jump and ‘esc’ to leave the world and back to the website.</b><br /></p>
             
             
             <h3>Interacting with the assistant</h3>
             <p>Please use the <b>chat box in the top left pane</b> to speak with and instruct the assistant. <br />
             <p>We ask that you interact with the agent for <b>at least 5 minutes.</b></p> 
-            <b>Press “submit” when you are ready to send the command to the assistant</b>. Once you send the command, you should be able to see the assistant execute the command in the 3-D world on bottom-left. The <b>assistant might also send you replies once in a while and you can see that below the “Submit” button</b>. <br />
+            <b>Press “submit” when you are ready to send the command to the assistant</b>. Once you send the command, you should be able to see the assistant execute the command in the 3-D world on bottom-left. The assistant might also send you replies once in a while and you can see that below the “Submit” button. <br />
             <b>The bot might be slow to respond due to network lag. You may expect a few seconds between sending a command and getting responses from the agent (we are improving it!).Please be patient and do not send multiple commands at a time</b>
             
-            <b>On the top right you will be able to see a history of the last 5 commands</b> you’ve sent to the assistant in the game.<b r/>
+            <p>On the bottom left you will be able to see a history of the last 5 commands you’ve sent to the assistant in the game. </p>
             <b>Keep in mind that the bot is non-violent. </b></p>
             <p>&nbsp;</p>
             
@@ -113,7 +113,12 @@
             <br />
             <p><b>You can talk to the bot as you would to another human player to instruct it to perform actions mentioned above, ask it questions, or to give it information.</b></p><br />
             
-            
+            <h3> Marking Errors </h3>
+            <p>If the agent fails to do something you asked, please mark the failure! <br />
+            <p>This is done by clicking the <b>"x"</b> button next to the command. </p> 
+            <img src="https://craftassist.s3-us-west-2.amazonaws.com/pubr/mark_error.png" width="640" height="570"></iframe>
+            <p>If the agent fails, you will be prompted for more information.</p> 
+
             <b>Please use your imagination to come up with things you'd like to say to the bot to make the interaction rich, given the bot’s capabilities. Be as creative as you can.</b> </br>
             <b>The instructions should be related to the bot's capabilities, please give us as much variety as you can.</b><br />
             <b>Remember that the bot is non-violent. Please click on the start button when you are ready and once finished, click on the “end” button to proceed to next steps.</b>


### PR DESCRIPTION
# Description

Adds a section on error marking to the Turk instructions for interacting with Dashboard.
<img width="1130" alt="mark_error" src="https://user-images.githubusercontent.com/19957918/118777490-f81b8100-b83d-11eb-9d84-05764e20b298.png">

In the Turker's browser:
<img width="1467" alt="Screen Shot 2021-05-19 at 12 33 26 AM" src="https://user-images.githubusercontent.com/19957918/118777725-3add5900-b83e-11eb-8be4-5a8d2ee0800c.png">

This updates both the task preview and the actual task UI.