### PR TITLE
Replace spaces with tab in makefile

### DIFF
--- a/droidlet/lowlevel/minecraft/Makefile
+++ b/droidlet/lowlevel/minecraft/Makefile
@@ -31,7 +31,7 @@ client:
 	cd client && \
 	rm -rf build && \
 	mkdir -p build && \
-        cd build && \
+	cd build && \
 	cmake .. && \
 	make
 


### PR DESCRIPTION
# Description

Replace spaces with tab in makefile. This is reported by @kavyasrinet that `make client` would fail locally even it passed the CI. 

Confirmed that it worked for me locally. Could you check? @kavyasrinet 


## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before:

`make client` failed locally

After:

`make client` succeeded.

# Testing

Tested locally.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

