### PR TITLE
launch_pyro_habitat fixes

### DIFF
--- a/locobot/robot/launch_pyro_habitat.sh
+++ b/locobot/robot/launch_pyro_habitat.sh
@@ -3,6 +3,16 @@
 export PYRO_SERIALIZER='pickle'
 export PYRO_SERIALIZERS_ACCEPTED='pickle'
 
+echo "Ensuring clean slate (kills python, roscore, rosmaster processes)..."
+killall -9 python &
+killall -9 roscore &
+killall -9 rosmaster &
+sleep 5
+
+echo "Launching environment ..."
+roscore &
+source /root/pyenv_pyrobot_python3/bin/activate && source /root/pyrobot_catkin_ws/devel/setup.bash
+
 default_ip=$(hostname -I)
 ip=${LOCOBOT_IP:-$default_ip}
 echo "Binding to Host IP" $ip


### PR DESCRIPTION
# Description

Adding a check to cleanup existing ros or python processes (in the form of Pyro4 servers) before launching. Previously two consecutive launches were erroring out.

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.


# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

