### PR TITLE
fixed dependency bug in locobot_agent

### DIFF
--- a/agents/locobot/locobot_agent.py
+++ b/agents/locobot/locobot_agent.py
@@ -26,14 +26,14 @@ from agents.loco_mc_agent import LocoMCAgent
 from agents.argument_parser import ArgumentParser
 from droidlet.memory.robot.loco_memory import LocoAgentMemory
 from droidlet.perception.robot import Perception, SelfPerception
-from droidlet.interpreter.robot import dance, default_behaviors
-
-from droidlet.dialog.robot.dialogue_objects import (
-    LocoBotCapabilities,
-    LocoGetMemoryHandler,
-    PutMemoryHandler,
+from droidlet.interpreter.robot import (
+    dance, 
+    default_behaviors,
+    LocoGetMemoryHandler, 
+    PutMemoryHandler, 
     LocoInterpreter,
 )
+from droidlet.dialog.robot import LocoBotCapabilities
 import droidlet.lowlevel.locobot.rotation as rotation
 from droidlet.lowlevel.locobot.locobot_mover import LoCoBotMover
 from droidlet.event import sio

--- a/droidlet/dialog/robot/__init__.py
+++ b/droidlet/dialog/robot/__init__.py
@@ -1,0 +1,3 @@
+from .dialogue_objects import LocoBotCapabilities
+
+__all__ = [LocoBotCapabilities]

--- a/droidlet/dialog/robot/dialogue_objects/__init__.py
+++ b/droidlet/dialog/robot/dialogue_objects/__init__.py
@@ -1,0 +1,3 @@
+from .loco_dialogue_object import LocoBotCapabilities
+
+__all__ = [LocoBotCapabilities]


### PR DESCRIPTION
# Description

The most recent refactor seemed to introduce a bug where running locobot_agent.py resulted in the following error: 
> ImportError: cannot import name 'LocoBotCapabilities' from 'droidlet.dialog.robot.dialogue_objects' (/raid/hollisma/droidlet/droidlet/dialog/robot/dialogue_objects/__init__.py)

Anurag and I went through and fixed the problem dependencies. 

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Stack trace for the bug: 
>Traceback (most recent call last):
  File "agents/locobot/locobot_agent.py", line 31, in <module>
    from droidlet.dialog.robot.dialogue_objects import (
ImportError: cannot import name 'LocoBotCapabilities' from 'droidlet.dialog.robot.dialogue_objects' (/raid/hollisma/droidlet/droidlet/dialog/robot/dialogue_objects/__init__.py)

# Testing

To reproduce, checkout the commit before this (7c271b12) and run agents/locobot/locobot_agent.py. 

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

