### PR TITLE
indicating status of command as an emoji next to the message

### DIFF
--- a/droidlet/dashboard/web/src/components/Interact/Message.js
+++ b/droidlet/dashboard/web/src/components/Interact/Message.js
@@ -32,12 +32,19 @@ class Message extends Component {
     this.elementRef = React.createRef();
   }
 
-  renderChatHistory() {
+  renderChatHistory(status) {
     //render the HTML for the chatHistory with a unique key value
     return this.props.chats.map((value, idx) =>
       React.cloneElement(
         <ListItem>
-          <ListItemText primary={value.msg} />
+          <ListItemText>
+            {value.msg +
+              (value.msg
+                ? status === "Sent successfully"
+                  ? " ✅"
+                  : " ❌"
+                : "")}
+          </ListItemText>
           <ListItemSecondaryAction>
             {value.msg !== "" ? (
               <IconButton
@@ -132,7 +139,7 @@ class Message extends Component {
           fontSize="large"
           onClick={this.toggleListen.bind(this)}
         ></KeyboardVoiceIcon>
-        <List>{this.renderChatHistory()}</List>
+        <List>{this.renderChatHistory(this.props.status)}</List>
         <div
           contentEditable="true"
           className="Msg single-line"
@@ -152,7 +159,6 @@ class Message extends Component {
           Submit{" "}
         </Button>
 
-        <p id="callbackMsg">{this.props.status}</p>
         <p id="assistantReply">{this.props.agent_reply} </p>
       </div>
     );


### PR DESCRIPTION
# Description

The command status on the dashboard is now displayed as an emoji next to the command in the history above the input box instead of a text message below the input box. Putting the display in this format and location makes it easier to see the status of the command as well as place it physically closer to the command history. 

A note: the red cross shows whenever the status is not a success. I'm not sure if there are other statuses where a red cross would not fit, but if this is the case, we can only display a checkmark if there's a success and display no emoji otherwise. 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Before and After

Before: the status is indicated under the input box. 
![image](https://user-images.githubusercontent.com/44927209/120534045-6409f780-c3af-11eb-9bd2-6acda249f47c.png)

After: the status is indicated next to the command above the input box. Green checkmark indicates the command was sent successfully while a red cross indicates that the command was not send successfully. 
![image](https://user-images.githubusercontent.com/44927209/120531524-b8f83e80-c3ac-11eb-876b-48d73ccec8a9.png)
![image](https://user-images.githubusercontent.com/44927209/120532688-edb8c580-c3ad-11eb-8f69-c5315ecaf71a.png)

# Testing

When entering a command, there is a brief moment when the message and status are out of sync (message is updated but status is not) and there is a red cross in this moment, but successful commands will quickly change to the green checkbox. 

I haven't encountered any scenarios where the status is something other than "Sent successfully", so to test the red cross, I hardcoded the condition statement to be false. 

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

