### PR TITLE
fixed duplicate commands from keypresses

### DIFF
--- a/droidlet/dashboard/web/src/StateManager.js
+++ b/droidlet/dashboard/web/src/StateManager.js
@@ -187,9 +187,11 @@ class StateManager {
 
   keyHandler(key_codes) {
     let commands = [];
+    let keys = [];
     for (var k in key_codes) {
       let val = key_codes[k];
       k = parseInt(k);
+      keys.push(k);
       if (val === true) {
         if (k === 38) {
           // Up
@@ -227,6 +229,11 @@ class StateManager {
     }
     if (commands.length > 0) {
       this.socket.emit("command", commands);
+
+      // Reset keys to prevent duplicates
+      for (let i in keys) {
+        key_codes[keys[i]] = false;
+      }
     }
   }
 

--- a/droidlet/dashboard/web/src/components/Navigator.js
+++ b/droidlet/dashboard/web/src/components/Navigator.js
@@ -28,9 +28,8 @@ class Navigator extends React.Component {
   componentDidMount() {
     var map = {};
     var onkey = function (e) {
-      map[e.keyCode] = e.type === "keydown";
+      map[e.keyCode] = true;
     };
-    document.addEventListener("keydown", onkey);
     document.addEventListener("keyup", onkey);
     setInterval(stateManager.keyHandler, 33.33, map);
   }


### PR DESCRIPTION
# Description

There was an issue where keypresses were resulting in multiple commands being send to the agent. For example, pressing the up arrow key could result in 3+ MOVE_FORWARD commands being processed. The fix implemented in this PR involves processing keypresses on keyups rather than rapidly checking keydowns. 

Fixes issue #101 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before, a keypress would result in multiple commands being processed by the agent. 
After, a keypress will always result in a single command being processed. 

# Testing

All 8 keys were tested and have been verified to send only one command for each keypress, no matter how long the keypress is. For the future, if we want to be able to input multiple commands by holding down a key (like in games), we would need to process both keydowns and keyups. However, the models currently take a long time to process each command, making correctness more important than convenience. 

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

