### PR TITLE
[Dashboard in Turk] Process S3 Turk logs and collate CSV

### DIFF
--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/process_s3_logs.py
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/process_s3_logs.py
@@ -8,16 +8,13 @@ import re
 from datetime import datetime
 import argparse
 
-# TURK_LOGS_DIRECTORY = "~/s3_logs"
-# TURK_OUTPUT_DIRECTORY = "~/s3_logs/processed_logs/"
-
 pd.set_option('display.max_rows', 10)
 
-def read_turk_logs(turk_logs_directory, turk_output_directory):
+def read_turk_logs(turk_logs_directory, turk_output_directory, filename):
     # Crawl turk logs directory
     all_turk_interactions = None
 
-    for csv_path in glob.glob('{turk_logs_dir}/**/{csv_filename}'.format(turk_logs_dir=turk_logs_directory, csv_filename='nsp_outputs.csv')):
+    for csv_path in glob.glob('{turk_logs_dir}/**/{csv_filename}'.format(turk_logs_dir=turk_logs_directory, csv_filename=filename + '.csv')):
         print(csv_path)
         with open(csv_path) as fd:
             # collect the NSP outputs CSV
@@ -36,7 +33,7 @@ def read_turk_logs(turk_logs_directory, turk_output_directory):
     print(all_turk_interactions.shape)
 
     # Pipe CSV outputs to another file
-    out_path = "{output_dir}/nsp_outputs_{timestamp}.csv".format(output_dir=turk_output_directory, timestamp=datetime.now().strftime("%Y-%m-%d"))
+    out_path = "{output_dir}/{filename}_{timestamp}.csv".format(output_dir=turk_output_directory, filename=filename, timestamp=datetime.now().strftime("%Y-%m-%d"))
     all_turk_interactions.to_csv(out_path)
 
 
@@ -44,7 +41,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--turk_logs_directory', help='where to read s3 logs from')
     parser.add_argument('--turk_output_directory', help='where to write the collated NSP outputs')
+    parser.add_argument('--filename', help='name of the CSV file we want to read, eg. nsp_outputs')
     args = parser.parse_args()
 
-    read_turk_logs(args.turk_logs_directory, args.turk_output_directory)
+    read_turk_logs(args.turk_logs_directory, args.turk_output_directory, args.filename)
     

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/process_s3_logs.py
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/process_s3_logs.py
@@ -1,0 +1,50 @@
+"""
+This script collects S3 logs from Turk and postprocesses them
+"""
+
+import glob
+import pandas as pd
+import re
+from datetime import datetime
+import argparse
+
+# TURK_LOGS_DIRECTORY = "~/s3_logs"
+# TURK_OUTPUT_DIRECTORY = "~/s3_logs/processed_logs/"
+
+pd.set_option('display.max_rows', 10)
+
+def read_turk_logs(turk_logs_directory, turk_output_directory):
+    # Crawl turk logs directory
+    all_turk_interactions = None
+
+    for csv_path in glob.glob('{turk_logs_dir}/**/{csv_filename}'.format(turk_logs_dir=turk_logs_directory, csv_filename='nsp_outputs.csv')):
+        print(csv_path)
+        with open(csv_path) as fd:
+            # collect the NSP outputs CSV
+            csv_file = pd.read_csv(csv_path, delimiter="|")
+            # add a column with the interaction log ID
+            interaction_log_id = re.search(r'\/([^\/]*)\/nsp_outputs.csv', csv_path).group(1)
+            csv_file["turk_log_id"] = interaction_log_id
+            if all_turk_interactions is None:
+                all_turk_interactions = csv_file
+            else:
+                all_turk_interactions = pd.concat([all_turk_interactions, csv_file], ignore_index=True)
+
+    # Drop duplicates
+    all_turk_interactions.drop_duplicates()
+    print(all_turk_interactions.head())
+    print(all_turk_interactions.shape)
+
+    # Pipe CSV outputs to another file
+    out_path = "{output_dir}/nsp_outputs_{timestamp}.csv".format(output_dir=turk_output_directory, timestamp=datetime.now().strftime("%Y-%m-%d"))
+    all_turk_interactions.to_csv(out_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--turk_logs_directory', help='where to read s3 logs from')
+    parser.add_argument('--turk_output_directory', help='where to write the collated NSP outputs')
+    args = parser.parse_args()
+
+    read_turk_logs(args.turk_logs_directory, args.turk_output_directory)
+    


### PR DESCRIPTION
# Description

This is a simple script that collates individual Turk interaction logs, deduplicates and assigns IDs to each interaction session based on the log file name (this can be improved to be the Mephisto agent ID instead going forward).

The script then dumps the pandas dataframe into a CSV at the specified output. Command line params are the turk logs input directory, the output location for CSV and file name, eg. "nsp_outputs.csv".

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After



# Testing
`python /path/to/droidlet/droidlet/tools/crowdsourcing/droidlet_static_html_task/process_s3_logs.py --turk_logs_directory=/path/to/s3_logs/ --turk_output_directory=/path/to/s3_logs/processed_logs/ --filename=nsp_outputs`

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

