### PR TITLE
showing object masks on dashboard

### DIFF
--- a/droidlet/dashboard/web/src/components/LiveObjects.js
+++ b/droidlet/dashboard/web/src/components/LiveObjects.js
@@ -6,7 +6,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 
 import React from "react";
 import { Rnd } from "react-rnd";
-import { Stage, Layer, Image as KImage, Rect, Text } from "react-konva";
+import { Stage, Layer, Image as KImage, Rect, Text, Shape } from "react-konva";
 import { schemeCategory10 as colorScheme } from "d3-scale-chromatic";
 import ObjectFixup from "./ObjectFixup";
 
@@ -141,6 +141,26 @@ class LiveObjects extends React.Component {
           fontSize={10}
         />
       );
+      for (let i = 0; i < obj.mask.length; i++) {
+        let mask = obj.mask[i];
+        renderedObjects.push(
+          <Shape
+            sceneFunc={(context, shape) => {
+              context.beginPath();
+              context.moveTo(mask[0][0] * scale, mask[0][1] * scale);
+              for (let i = 1; i < mask.length; i++) {
+                context.lineTo(mask[i][0] * scale, mask[i][1] * scale);
+              }
+              context.closePath();
+              context.fillStrokeShape(shape);
+            }}
+            fill={color}
+            opacity={0.3}
+            stroke="black"
+            strokeWidth={1}
+          />
+        );
+      }
     });
 
     return (

--- a/droidlet/perception/robot/handlers/detector.py
+++ b/droidlet/perception/robot/handlers/detector.py
@@ -9,6 +9,7 @@ import numpy as np
 import pickle
 import tempfile
 import logging
+from imantics import Mask
 
 from detectron2.data import MetadataCatalog
 from detectron2.utils.visualizer import ColorMode
@@ -190,12 +191,16 @@ class Detection(WorldObject):
 
     def to_struct(self):
         bbox = self._maybe_bbox(self.bbox, self.mask)
+        mask_arr = self.mask.cpu().detach().numpy()
+        mask_points_nd = Mask(mask_arr).polygons().points
+        mask_points = list(map(lambda x: x.tolist(), mask_points_nd))
         return {
             "id": self.eid,
             "xyz": list(self.xyz),
             "bbox": bbox,
             "label": self.label,
             "properties": "\n ".join(self.properties if self.properties is not None else ""),
+            "mask": mask_points,
         }
 
     def get_masked_img(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ docopt>=0.6.2
 docutils>=0.14
 flake8>=3.5.0
 flake8-mypy>=17.8.0
+imantics>=0.1.12
 ipdb>=0.11
 ipython-genutils>=0.2.0
 ipython>=6.3.1


### PR DESCRIPTION
# Description

Included the object masks in the object detection camera feed on the dashboard, making it easier to see how objects are being detected. The object mask is implemented as a transparent, colored overlay over the pixels included in the mask. 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before: only bounding boxes are showing
![image](https://user-images.githubusercontent.com/44927209/121070852-36e98a80-c79d-11eb-8ce9-94c6e42e635a.png)

After: object masks are shown with a transparent, colored overlay
![image](https://user-images.githubusercontent.com/44927209/121072575-6600fb80-c79f-11eb-9155-ba6bed8665db.png)

# Testing

To test, build the project and run locobot_agent.py. The mask detection is somewhat inconsistent and objects that are detected sometimes are not detected if the camera rotates slightly. Many objects also have non-connected masks were there are non-overlapping masks for the same object. 

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

