### PR TITLE
[Dashboard in Turk] Create free form and multiple choice onboarding tasks

### DIFF
--- a/droidlet/tools/crowdsourcing/README.md
+++ b/droidlet/tools/crowdsourcing/README.md
@@ -40,6 +40,9 @@ subdomain,batch
 
 We can access these template variables directly in the HTML tasks.
 
+### Static Files
+To use static resources such as images to your task, you can add them to `droidlet_static_html_task/server_files/extra_refs/`. (This is currently empty, but Mephisto expects this path.)
+
 ### Running tasks
 Run the following command to start a `droidlet_static_html_task` with `heroku` architect and `flask` server type
 
@@ -48,7 +51,31 @@ python droidlet_static_html_task/static_test_script.py mephisto.architect.server
 ```
 
 You can replace `droidlet_static_html_task/static_test_script.py` with any mephisto task you would like to run and replace `<path_to_server>` with any heroku server setup you would like to use. For `servermgr` which serves our craftassist.io backend, the code is in `~/droidlet/crowdsourcing/servermgr`.
+
+### Running tasks with Onboarding
+The onboarding workflow is as follows:
+1. Turk worker accepts task. If the Turk worker has completed and passed this onboarding flow before, the worker is auto-approved. If the worker failed this task before, the worker is denied. Otherwise, the Turker must do the onboarding task.
+2. New Turker is shown onboarding task with instructions that are almost identical to the setup of the main task, eg. including bot capabilities and what is allowed/disallowed and encouraged. In the free form onboarding flow, worker is asked to write up to N instructions for the robot assistant in a text box.
+3. On form submit, the response is processed and we run a series of checks to validate the quality of interactions: number of commands, richness, diversity. Onboarding tasks are only successful if they pass all these checks.
+4. Turk worker success or failure is recorded in Mephisto DB, and successful workers are taken to the primary task.
+
+
+Run the following command to start a `droidlet_static_html_task` with onboarding using the `local` architect:
+```
+python droidlet_static_html_task/static_run_with_onboarding.py mephisto/architect=local
+```
+Make sure port 3000 is tunneled on your mac.
+
+Run the following command to run the above in the MTurk sandbox.
+```
+python droidlet_static_html_task/static_run_with_onboarding.py mephisto/architect=heroku mephisto.provider.requester_name=[username]_sandbox
+```
+You will need to log into your MTurk account if you are not already logged in.
+
+Note that currently the onboarding flow does not work with the `flask` server type, so we use the default `node` server type in Mephisto.
+
 ## Extra configs for using servermgr
+This section is for workflows that deploy an external server. This is currently not necessary for our Droidlet dashboard task runs if ECS instances are pre-launched and IPs are passed into Turk tasks via Mephisto configs.
 
 Since we are requesting ECS instance in servermgr flask app. It's required to set up aws-specific information as environment variable passed to heroku. Make sure the following hydra variables are set in your mephisto config file in `conf/example.yaml`:
 

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/conf/onboarding_example.yaml
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/conf/onboarding_example.yaml
@@ -5,7 +5,7 @@ mephisto:
     task_source: ${task_dir}/server_files/craftassist_task.html
     preview_source: ${task_dir}/server_files/craftassist_task_preview.html
     extra_source_dir: ${task_dir}/server_files/extra_refs
-    onboarding_source: ${task_dir}/server_files/craftassist_task_onboarding.html
+    onboarding_source: ${task_dir}/server_files/onboarding_free_form.html
     onboarding_qualification: droidlet-static-onboarding-qual
     units_per_assignment: 1
   task:

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/conf/onboarding_example.yaml
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/conf/onboarding_example.yaml
@@ -1,0 +1,16 @@
+#@package _global_
+mephisto:
+  blueprint:
+    data_csv: ${task_dir}/data.csv
+    task_source: ${task_dir}/server_files/craftassist_task.html
+    preview_source: ${task_dir}/server_files/craftassist_task_preview.html
+    extra_source_dir: ${task_dir}/server_files/extra_refs
+    onboarding_source: ${task_dir}/server_files/craftassist_task_onboarding.html
+    onboarding_qualification: droidlet-static-onboarding-qual
+    units_per_assignment: 1
+  task:
+    task_title: "Craftassist Task"
+    task_description: "Interact with an assistant in a 3-D world creative game."
+    task_reward: 2.0
+    task_tags: "static,task,testing"
+    task_name: "droidlet-dashboard"

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/server_files/craftassist_task_onboarding.html
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/server_files/craftassist_task_onboarding.html
@@ -1,0 +1,128 @@
+<!-- Bootstrap v3.0.3 -->
+<link
+  rel="stylesheet"
+  href="https://stackpath.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+/>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<!-- Modal --><!-- MODAL -->
+<!-- Content -->
+
+<section
+  class="container"
+  id="Other"
+  style="
+    margin-bottom: 15px;
+    padding: 10px;
+    font-family: Verdana, Geneva, sans-serif;
+    font-size: 0.9em;
+  "
+>
+  <div class="row col-xs-12 col-md-12">
+    <!-- Instructions -->
+    <div class="panel panel-primary">
+      <div class="panel-heading">
+        <strong> Instructions </strong>
+      </div>
+
+      <div class="panel-body" id="instructions">
+        <h1><strong>Interact with an assistant in a 3-D world creative game.</strong></h1>
+            
+            <img src="https://craftassist.s3-us-west-2.amazonaws.com/pubr/voxel_world_agent.png" width="320" height="240"></iframe>
+            <img src="https://craftassist.s3-us-west-2.amazonaws.com/pubr/voxel_2.png" width="320" height="240"></iframe>
+            <img src="https://craftassist.s3-us-west-2.amazonaws.com/pubr/voxel_3.png" width="320" height="240"></iframe>
+            
+            <p><b>Imagine you are playing a creative game in a 3-D voxel world and you have access to an assistant (as shown in some screenshots above) that can help you get things done.</b><br />
+            <b>Use your imagination and creativity to interact with the assistant. In the setup here, you will be logged in to the voxel world along with the assistant.</b><br />
+            </p>
+
+            <b>Keep in mind that the robot assistant is non-violent. </b></p>
+            <p>&nbsp;</p>
+            
+            <b>You can assume that the robot has the following capabilities:</b>
+            <ul>
+                <li><b>Move</b> (the bot can be told to move around to places, objects, things etc)</li>
+                <li><b>Build</b> (the bot can be told to build things)</li>
+                <li><b>Destroy</b> (the bot can be told to destroy things)</li>
+                <li><b>Dance</b> (the bot can be told to do a movement of some kind)</li>
+                <li><b>Get</b> (the bot can be told to get things from one place to another)</li>
+                <li><b>Tag</b> (the bot can be told to tag things)</li>
+                <li><b>Dig</b> (the bot can be told to dig up things)</li>
+                <li><b>Copy</b> (the bot can be told to make a copy of things)</li>
+                <li><b>Undo</b> (the bot can be told to revert things)</li>
+                <li><b>Fill</b> (the bot can be told to fill up structures)</li>
+                <li><b>Spawn</b> (the bot can be told to spawn objects)</li>
+                <li><b>Answer</b> (the bot can be told to answer your questions)</li>
+                <li><b>Stop</b> (the bot can be told to stop)</li>
+                <li><b>Resume</b> (the bot can be told to resume an earlier action)</li>
+            </ul>
+            <br />
+            <p><b>You can talk to the bot as you would to another human player to instruct it to perform actions mentioned above, ask it questions, or to give it information.</b></p><br />
+
+      </div>
+    </div>
+    <!-- End Instructions -->
+    <!-- Content Body -->
+
+    <section>
+      <fieldset>
+        <div class="input-group">
+          <label> Which of these commands is not a valid command to give to the bot? </label>
+          <select class="form-control" name="answer">
+            <option selected="selected" value="">(select one)</option>
+            <option value="build_house">Build a house</option>
+            <option value="dig_hole">Dig a hole</option>
+            <option value="kill_everything">Kill everything</option>
+            <option value="move_left">Move left until you reach the tree</option>
+          </select>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <div class="input-group">
+          <label> Which of these commands is outside of the bot's capabilities? </label>
+          <select class="form-control" name="answer">
+            <option selected="selected" value="">(select one)</option>
+            <option value="stop_what_you_are_doing">Stop what you are doing immediately</option>
+            <option value="make_sky_pink">Make the sky pink</option>
+            <option value="tag_location_x">Tag this location as X</option>
+            <option value="jump_in_circle">Jump around in a circle</option>
+          </select>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <div><p><b>Watch the following series of user interactions and assistant responses. The assistant is the figure with yellow hair in the top right (the red human is the speaker). 
+            Then answer the following questions.
+        </b></p></div>
+        <img src="https://craftassist.s3-us-west-2.amazonaws.com/pubr/dashboard-demo-2.gif" width="960" height="720">
+        <br />
+        <div class="input-group">
+          <label> Are the bot's actions correct for the command "build a square"? </label>
+          <select class="form-control" name="answer">
+            <option selected="selected" value="">(select one)</option>
+            <option value="yes">Yes</option>
+            <option value="no">No</option>
+          </select>
+        </div>
+      </fieldset>
+    </section>
+    <!-- End Content Body -->
+  </div>
+</section>
+
+<!-- Can also show them a video of actions getting executed and ask if it is error -->
+
+<style type="text/css">
+  fieldset {
+    padding: 10px;
+    background: #fbfbfb;
+    border-radius: 5px;
+    margin-bottom: 5px;
+  }
+
+  .input_location {
+    background-color: blanchedalmond;
+    padding: 10px;
+  }
+</style>

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/server_files/craftassist_task_onboarding.html
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/server_files/craftassist_task_onboarding.html
@@ -68,7 +68,7 @@
       <fieldset>
         <div class="input-group">
           <label> Which of these commands is not a valid command to give to the bot? </label>
-          <select class="form-control" name="answer">
+          <select class="form-control" name="answer0">
             <option selected="selected" value="">(select one)</option>
             <option value="build_house">Build a house</option>
             <option value="dig_hole">Dig a hole</option>
@@ -81,7 +81,7 @@
       <fieldset>
         <div class="input-group">
           <label> Which of these commands is outside of the bot's capabilities? </label>
-          <select class="form-control" name="answer">
+          <select class="form-control" name="answer1">
             <option selected="selected" value="">(select one)</option>
             <option value="stop_what_you_are_doing">Stop what you are doing immediately</option>
             <option value="make_sky_pink">Make the sky pink</option>
@@ -99,7 +99,7 @@
         <br />
         <div class="input-group">
           <label> Are the bot's actions correct for the command "build a square"? </label>
-          <select class="form-control" name="answer">
+          <select class="form-control" name="answer2">
             <option selected="selected" value="">(select one)</option>
             <option value="yes">Yes</option>
             <option value="no">No</option>

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/server_files/onboarding_free_form.html
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/server_files/onboarding_free_form.html
@@ -67,7 +67,7 @@
     <section>
       <fieldset>
         <div class="input-group">
-          <label>Please type up to 10 commands that you would give the robot assistant, with one command on each line. When you are done, press "Submit" </label>
+          <label>Please type up to 5 commands that you would give the robot assistant, with one command on each line. When you are done, press "Submit" </label>
           <textarea class="form-control" rows="10" name="answer"></textarea>
         </div>
       </fieldset>

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/server_files/onboarding_free_form.html
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/server_files/onboarding_free_form.html
@@ -1,0 +1,93 @@
+<!-- Bootstrap v3.0.3 -->
+<link
+  rel="stylesheet"
+  href="https://stackpath.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+/>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<!-- Modal --><!-- MODAL -->
+<!-- Content -->
+
+<section
+  class="container"
+  id="Other"
+  style="
+    margin-bottom: 15px;
+    padding: 10px;
+    font-family: Verdana, Geneva, sans-serif;
+    font-size: 0.9em;
+  "
+>
+  <div class="row col-xs-12 col-md-12">
+    <!-- Instructions -->
+    <div class="panel panel-primary">
+      <div class="panel-heading">
+        <strong> Instructions </strong>
+      </div>
+
+      <div class="panel-body" id="instructions">
+        <h1><strong>Interact with an assistant in a 3-D world creative game.</strong></h1>
+            
+            <img src="https://craftassist.s3-us-west-2.amazonaws.com/pubr/voxel_world_agent.png" width="320" height="240"></iframe>
+            <img src="https://craftassist.s3-us-west-2.amazonaws.com/pubr/voxel_2.png" width="320" height="240"></iframe>
+            <img src="https://craftassist.s3-us-west-2.amazonaws.com/pubr/voxel_3.png" width="320" height="240"></iframe>
+            
+            <p><b>Imagine you are playing a creative game in a 3-D voxel world and you have access to an assistant (as shown in some screenshots above) that can help you get things done.</b><br />
+            <b>Use your imagination and creativity to interact with the assistant. In the setup here, you will be logged in to the voxel world along with the assistant.</b><br />
+            </p>
+
+            <b>Keep in mind that the robot assistant is non-violent. </b></p>
+            <p>&nbsp;</p>
+            
+            <b>You can assume that the robot has the following capabilities:</b>
+            <ul>
+                <li><b>Move</b> (the bot can be told to move around to places, objects, things etc)</li>
+                <li><b>Build</b> (the bot can be told to build things)</li>
+                <li><b>Destroy</b> (the bot can be told to destroy things)</li>
+                <li><b>Dance</b> (the bot can be told to do a movement of some kind)</li>
+                <li><b>Get</b> (the bot can be told to get things from one place to another)</li>
+                <li><b>Tag</b> (the bot can be told to tag things)</li>
+                <li><b>Dig</b> (the bot can be told to dig up things)</li>
+                <li><b>Copy</b> (the bot can be told to make a copy of things)</li>
+                <li><b>Undo</b> (the bot can be told to revert things)</li>
+                <li><b>Fill</b> (the bot can be told to fill up structures)</li>
+                <li><b>Spawn</b> (the bot can be told to spawn objects)</li>
+                <li><b>Answer</b> (the bot can be told to answer your questions)</li>
+                <li><b>Stop</b> (the bot can be told to stop)</li>
+                <li><b>Resume</b> (the bot can be told to resume an earlier action)</li>
+            </ul>
+            <br />
+            <p><b>You can talk to the bot as you would to another human player to instruct it to perform actions mentioned above, ask it questions, or to give it information.</b></p><br />
+
+      </div>
+    </div>
+    <!-- End Instructions -->
+    <!-- Content Body -->
+
+    <section>
+      <fieldset>
+        <div class="input-group">
+          <label>Please type up to 10 commands that you would give the robot assistant, with one command on each line. When you are done, press "Submit" </label>
+          <textarea class="form-control" rows="10"></textarea>
+        </div>
+      </fieldset>
+    </section>
+    <!-- End Content Body -->
+  </div>
+</section>
+
+<!-- Can also show them a video of actions getting executed and ask if it is error -->
+
+<style type="text/css">
+  fieldset {
+    padding: 10px;
+    background: #fbfbfb;
+    border-radius: 5px;
+    margin-bottom: 5px;
+  }
+
+  .input_location {
+    background-color: blanchedalmond;
+    padding: 10px;
+  }
+</style>

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/server_files/onboarding_free_form.html
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/server_files/onboarding_free_form.html
@@ -68,7 +68,7 @@
       <fieldset>
         <div class="input-group">
           <label>Please type up to 10 commands that you would give the robot assistant, with one command on each line. When you are done, press "Submit" </label>
-          <textarea class="form-control" rows="10"></textarea>
+          <textarea class="form-control" rows="10" name="answer"></textarea>
         </div>
       </fieldset>
     </section>

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/static_run_with_onboarding.py
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/static_run_with_onboarding.py
@@ -20,7 +20,7 @@ from omegaconf import DictConfig
 from dataclasses import dataclass, field
 from typing import List, Any
 
-TASK_DIRECTORY = "/private/home/rebeccaqian/droidlet/droidlet/tools/crowdsourcing/droidlet_static_html_task/"
+TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 defaults = [
     {"mephisto/blueprint": BLUEPRINT_TYPE},

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/static_run_with_onboarding.py
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/static_run_with_onboarding.py
@@ -50,11 +50,13 @@ def main(cfg: DictConfig) -> None:
         # NOTE: depending on which OS Turker uses, there could be carriage returns \r or just newlines \n
         # this python module should handle all cases
         commands = answer_str.splitlines()
+        # filter empty commands
+        filtered_commands = [x for x in commands if x != ""]
         # Number check: Check that the number of commands >= 3
         if len(commands) < 3:
             return False
         # Length check: Check that the average number of words in commands > 4
-        commands_split = [x.split(" ") for x in commands]
+        commands_split = [x.split(" ") for x in filtered_commands]
         avg_words_in_commands = sum(map(len, commands_split)) / len(commands_split)
         if avg_words_in_commands < 2:
             return False

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/static_run_with_onboarding.py
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/static_run_with_onboarding.py
@@ -22,7 +22,7 @@ from typing import List, Any
 
 TASK_DIRECTORY = "/private/home/rebeccaqian/droidlet/droidlet/tools/crowdsourcing/droidlet_static_html_task/"
 
-CORRECT_ANSWER = "apple"
+CORRECT_ANSWER = "yes"
 
 defaults = [
     {"mephisto/blueprint": BLUEPRINT_TYPE},
@@ -51,7 +51,24 @@ def main(cfg: DictConfig) -> None:
     def onboarding_is_valid(onboarding_data):
         inputs = onboarding_data["inputs"]
         outputs = onboarding_data["outputs"]
-        return outputs.get("answer") == correct_config_answer
+        answer_str = outputs["answer"]
+        # NOTE: depending on which OS Turker uses, there could be carriage returns \r or just newlines \n
+        # this python module should handle all cases
+        commands = answer_str.splitlines()
+        # Number check: Check that the number of commands >= 3
+        if len(commands) < 3:
+            return False
+        # Length check: Check that the average number of words in commands > 4
+        commands_split = [x.split(" ") for x in commands]
+        avg_words_in_commands = sum(map(len, commands_split)) / len(commands_split)
+        if avg_words_in_commands < 2:
+            return False
+        # TODO: Grammar check: Check that there is punctuation, capitals
+        # Diversity check: Check that commands are reasonably diverse
+        first_words = [x[0] for x in commands_split]
+        if len(set(first_words)) == 1:
+            return False
+        return True
 
     shared_state = SharedStaticTaskState(
         onboarding_data={"correct_answer": correct_config_answer},

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/static_run_with_onboarding.py
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/static_run_with_onboarding.py
@@ -22,8 +22,6 @@ from typing import List, Any
 
 TASK_DIRECTORY = "/private/home/rebeccaqian/droidlet/droidlet/tools/crowdsourcing/droidlet_static_html_task/"
 
-CORRECT_ANSWER = "yes"
-
 defaults = [
     {"mephisto/blueprint": BLUEPRINT_TYPE},
     {"mephisto/architect": "local"},
@@ -38,7 +36,6 @@ from mephisto.operations.hydra_config import RunScriptConfig, register_script_co
 class TestScriptConfig(RunScriptConfig):
     defaults: List[Any] = field(default_factory=lambda: defaults)
     task_dir: str = TASK_DIRECTORY
-    correct_answer: str = CORRECT_ANSWER
 
 
 register_script_config(name="scriptconfig", module=TestScriptConfig)
@@ -46,10 +43,8 @@ register_script_config(name="scriptconfig", module=TestScriptConfig)
 
 @hydra.main(config_name="scriptconfig")
 def main(cfg: DictConfig) -> None:
-    correct_config_answer = cfg.correct_answer
 
     def onboarding_is_valid(onboarding_data):
-        inputs = onboarding_data["inputs"]
         outputs = onboarding_data["outputs"]
         answer_str = outputs["answer"]
         # NOTE: depending on which OS Turker uses, there could be carriage returns \r or just newlines \n
@@ -63,15 +58,15 @@ def main(cfg: DictConfig) -> None:
         avg_words_in_commands = sum(map(len, commands_split)) / len(commands_split)
         if avg_words_in_commands < 2:
             return False
-        # TODO: Grammar check: Check that there is punctuation, capitals
         # Diversity check: Check that commands are reasonably diverse
         first_words = [x[0] for x in commands_split]
         if len(set(first_words)) == 1:
             return False
+        # TODO: Grammar check: Check that there is punctuation, capitals
         return True
 
     shared_state = SharedStaticTaskState(
-        onboarding_data={"correct_answer": correct_config_answer},
+        onboarding_data={},
         validate_onboarding=onboarding_is_valid,
     )
 

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/static_run_with_onboarding.py
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/static_run_with_onboarding.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from mephisto.operations.operator import Operator
+from mephisto.operations.utils import get_root_dir
+from mephisto.tools.scripts import load_db_and_process_config
+from mephisto.abstractions.blueprints.static_html_task.static_html_blueprint import (
+    BLUEPRINT_TYPE,
+)
+from mephisto.abstractions.blueprints.abstract.static_task.static_blueprint import (
+    SharedStaticTaskState,
+)
+
+import hydra
+from omegaconf import DictConfig
+from dataclasses import dataclass, field
+from typing import List, Any
+
+TASK_DIRECTORY = "/private/home/rebeccaqian/droidlet/droidlet/tools/crowdsourcing/droidlet_static_html_task/"
+
+CORRECT_ANSWER = "apple"
+
+defaults = [
+    {"mephisto/blueprint": BLUEPRINT_TYPE},
+    {"mephisto/architect": "local"},
+    {"mephisto/provider": "mock"},
+    {"conf": "onboarding_example"},
+]
+
+from mephisto.operations.hydra_config import RunScriptConfig, register_script_config
+
+
+@dataclass
+class TestScriptConfig(RunScriptConfig):
+    defaults: List[Any] = field(default_factory=lambda: defaults)
+    task_dir: str = TASK_DIRECTORY
+    correct_answer: str = CORRECT_ANSWER
+
+
+register_script_config(name="scriptconfig", module=TestScriptConfig)
+
+
+@hydra.main(config_name="scriptconfig")
+def main(cfg: DictConfig) -> None:
+    correct_config_answer = cfg.correct_answer
+
+    def onboarding_is_valid(onboarding_data):
+        inputs = onboarding_data["inputs"]
+        outputs = onboarding_data["outputs"]
+        return outputs.get("answer") == correct_config_answer
+
+    shared_state = SharedStaticTaskState(
+        onboarding_data={"correct_answer": correct_config_answer},
+        validate_onboarding=onboarding_is_valid,
+    )
+
+    db, cfg = load_db_and_process_config(cfg)
+    operator = Operator(db)
+
+    operator.validate_and_run_config(cfg.mephisto, shared_state)
+    operator.wait_for_runs_then_shutdown(skip_input=True, log_rate=30)
+
+
+if __name__ == "__main__":
+    main()

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/static_test_script.py
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/static_test_script.py
@@ -17,7 +17,8 @@ from omegaconf import DictConfig
 from dataclasses import dataclass, field
 from typing import List, Any
 
-TASK_DIRECTORY = "/Users/rebeccaqian/droidlet/crowdsourcing/droidlet_static_html_task"
+TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
+
 defaults = [
     {"mephisto/blueprint": BLUEPRINT_TYPE},
     {"mephisto/architect": "local"},


### PR DESCRIPTION
# Description

This PR sets up free form (default) and multiple choice onboarding tasks for Turkers.

Turker onboarding flow:
1. Turk worker accepts task. If the Turk worker has completed and passed this onboarding flow before, the worker is auto-approved. If the worker failed this task before, the worker is denied. Otherwise, the Turker must do the onboarding task.
2. The Turker is shown onboarding task with instructions that are almost identical to the voxel world setup, including bot capabilities and what is allowed/disallowed and encouraged, and is asked to write up to 10 instructions for the robot assistant in a text box.
3. On form submit, the response is processed and we run a series of checks to validate the quality of interactions: number of commands, richness, diversity. Onboarding tasks are only successful if they pass all these checks.
4. Turk worker success or failure is recorded in Mephisto DB, and successful workers are taken to the primary task.


Additional changes/notes in this PR:
- Added back the `extra_refs` directory that was removed during refactor.
- Removed hard coded task directory in run script.
- Additional checks we are not currently running:
    - Check free form inputs against a words blacklist
    - Grammar/spellcheck

Fixes # (issue)
#448 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before: Crowdsourced workers were shown the Craftassist task directly upon task acceptance, i.e.
<img width="1651" alt="Screen Shot 2021-06-07 at 12 42 46 PM" src="https://user-images.githubusercontent.com/19957918/121087477-5b436800-c799-11eb-9c49-f024f8e972ea.png">

After: Crowdsourced workers are first shown an onboarding task. If they fail, their IDs are recorded in Mephisto DB and they are prevented from working on future tasks using this onboarding qualification. If they pass, they are taken directly to the task.

![193146280_966286060799975_1159198245276520234_n](https://user-images.githubusercontent.com/19957918/121088268-54692500-c79a-11eb-83dd-b9a1c822942f.png)

# Testing

To run locally:
```
python droidlet_static_html_task/static_run_with_onboarding.py mephisto/architect=local
```

Make sure port 3000 is tunneled on your mac.

To run using Turk sandbox:
```
python droidlet_static_html_task/static_run_with_onboarding.py mephisto/architect=heroku mephisto.provider.requester_name=[username]_sandbox
```

Log in with team MTurk account.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

