### PR TITLE
[dashboard] Fixes the error 'ValueError: Too many packets in payload' after update to EngineIO v3.10.0+

### DIFF
--- a/droidlet/dashboard/__init__.py
+++ b/droidlet/dashboard/__init__.py
@@ -9,6 +9,10 @@ import json
 import random
 import ssl
 
+# https://github.com/miguelgrinberg/python-engineio/issues/142
+from engineio.payload import Payload
+Payload.max_decode_packets = 5000000
+
 try:
     import html
 


### PR DESCRIPTION
The issue comes from a upstream package issue.

See: https://github.com/miguelgrinberg/python-engineio/issues/142 for more context