### PR TITLE
[Testing] Fix SHARED_PATH for local test runs

### DIFF
--- a/agents/craftassist/tests/test.sh
+++ b/agents/craftassist/tests/test.sh
@@ -5,7 +5,7 @@
 
 cd $(dirname $0)
 
-SHARED_PATH=/shared
+SHARED_PATH=./shared
 COV_RELATIVE=craftassist
 
 pytest --cov-report=xml:$SHARED_PATH/test_MC.xml --cov=$COV_RELATIVE . --disable-pytest-warnings


### PR DESCRIPTION
# Description

Currently, running craftassist unit tests on devfair outputs a permissions error on accessing `/shared`.  This PR changes the `SHARED_PATH` config to `./shared`.

Note that there is an unrelated issue with the code coverage module, which I've filed #488 for.
 
Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before: P421890360
Permissions error accessing `/shared` on devfair

After: P421955341

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

