### PR TITLE
Fix perceive bug in craftassist agent

### DIFF
--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -185,9 +185,15 @@ class CraftAssistAgent(LocoMCAgent):
         )
 
     def perceive(self, force=False):
+        """Whenever some blocks are changed, that area will be put into a 
+        buffer which will be force-perceived by the agent in the next step
+
+        Here the agent first clusters areas that are overlapping on the buffer,
+        then run through all perception modules to perceive
+        and finally clear the buffer when perception is done.
+        """
         self.areas_to_perceive = cluster_areas(self.areas_to_perceive)
-        for v in self.perception_modules.values():
-            v.perceive(force=force)
+        super().perceive()
         self.areas_to_perceive = []
 
     def get_time(self):


### PR DESCRIPTION
# Description

This PR fixed the bug where craftassist agent won't respond to any human-given commands after the parser/perception refactor.

This is due to `perceive()` fn of parent class (loco_mc_agent) not get called in `perceive()` fn of craftassist. Simply add this fn call solved this issue.

Fixes # (issue)

#497 

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

**Before**

Agent won't respond to any human-given commands

**After**

Agent can respond to human-given commands.

# Testing

Tested locally by entering the the game and give commands. The agent can respond to commands now.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

