### PR TITLE
[Dashboard in Turk] Fully Automate Text to Tree Annotations Pipeline

### DIFF
--- a/tools/annotation_tools/turk_with_s3/construct_final_action_dict.py
+++ b/tools/annotation_tools/turk_with_s3/construct_final_action_dict.py
@@ -2,49 +2,42 @@ import ast
 import json
 import copy
 from pprint import pprint
-from os import path
+import os
+import argparse
 
 
-# output of tool D
-parent_folder = "/Users/rebeccaqian/minecraft/tools/annotation_tools/turk_with_s3/"
-folder_name_D = parent_folder + "D/"
-tool_D_out_file = folder_name_D + "all_agreements.txt"
-
-# output of tool C
-parent_folder = "/Users/rebeccaqian/minecraft/tools/annotation_tools/turk_with_s3/"
-folder_name_C = parent_folder + "C/"
-tool_C_out_file = folder_name_C + "all_agreements.txt"
-
-# combine outputs
-# check if all keys of tool C annotated yes -> put directly
-# if no , check child in t2 and combine
-# construct mape of tool 1
+# Construct maps of tools A->D
 toolC_map = {}
-
-if path.exists(tool_C_out_file):
-    with open(tool_C_out_file) as f:
-        for line in f.readlines():
-            line = line.strip()
-            cmd, ref_obj_text, a_d = line.split("\t")
-            if cmd in toolC_map:
-                toolC_map[cmd].update(ast.literal_eval(a_d))
-            else:
-                toolC_map[cmd] = ast.literal_eval(a_d)
-print(len(toolC_map.keys()))
-
-# construct map of tool 2
 toolD_map = {}
+toolA_map = {}
+toolB_map = {}
+toolC_updated_map = {}
 
-if path.exists(tool_D_out_file):
-    with open(tool_D_out_file) as f2:
-        for line in f2.readlines():
-            line = line.strip()
-            cmd, comparison_text, comparison_dict = line.split("\t")
-            if cmd in toolD_map:
-                print("BUGGGGG")
-            # add the comparison dict to command -> dict
-            toolD_map[cmd] = ast.literal_eval(comparison_dict)
-print(len(toolD_map.keys()))
+
+def collect_tool_outputs(tool_C_out_file, tool_D_out_file):
+    # check if all keys of tool C annotated yes -> put directly
+    # if no , check child in t2 and combine
+    if os.path.exists(tool_C_out_file):
+        with open(tool_C_out_file) as f:
+            for line in f.readlines():
+                line = line.strip()
+                cmd, ref_obj_text, a_d = line.split("\t")
+                if cmd in toolC_map:
+                    toolC_map[cmd].update(ast.literal_eval(a_d))
+                else:
+                    toolC_map[cmd] = ast.literal_eval(a_d)
+    print(len(toolC_map.keys()))
+
+    if os.path.exists(tool_D_out_file):
+        with open(tool_D_out_file) as f2:
+            for line in f2.readlines():
+                line = line.strip()
+                cmd, comparison_text, comparison_dict = line.split("\t")
+                if cmd in toolD_map:
+                    print("Error: command {} is in the tool D outputs".format(cmd))
+                # add the comparison dict to command -> dict
+                toolD_map[cmd] = ast.literal_eval(comparison_dict)
+    print(len(toolD_map.keys()))
 
 
 def all_yes(a_dict):
@@ -112,78 +105,67 @@ def fix_ref_obj(clean_dict):
     return new_clean_dict
 
 
-# combine and write output to a file
-i = 0
-# what these action will look like in the map
+def combine_and_write_outputs(tool_A_out_file, tool_B_out_file):
+    # combine and write output to a file
+    i = 0
+    # what these action will look like in the map
 
-toolC_updated_map = {}
+    # update dict of toolC with tool D and keep that in tool C's map
+    for cmd, a_dict in toolC_map.items():
+        # remove the ['yes', val] etc
+        for key in a_dict.keys():
+            a_dict_child = a_dict[key]
+            clean_dict = clean_up_dict(a_dict_child)
+            # fix reference object inside location of reference object
+            if "location" in clean_dict and "reference_object" in clean_dict["location"]:
+                value = clean_dict["location"]["reference_object"]
+                clean_dict["location"]["reference_object"] = fix_ref_obj(value)
+            new_clean_dict = fix_ref_obj(clean_dict)
 
-# update dict of toolC with tool D and keep that in tool C's map
-for cmd, a_dict in toolC_map.items():
-    # remove the ['yes', val] etc
-    for key in a_dict.keys():
-        a_dict_child = a_dict[key]
-        clean_dict = clean_up_dict(a_dict_child)
-        # fix reference object inside location of reference object
-        if "location" in clean_dict and "reference_object" in clean_dict["location"]:
-            value = clean_dict["location"]["reference_object"]
-            clean_dict["location"]["reference_object"] = fix_ref_obj(value)
-        new_clean_dict = fix_ref_obj(clean_dict)
+            if all_yes(a_dict_child):
+                if cmd in toolC_updated_map:
+                    toolC_updated_map[cmd][key] = new_clean_dict
+                else:
+                    toolC_updated_map[cmd] = {key: new_clean_dict}
+                continue
+            new_clean_dict.pop("comparison", None)
+            comparison_dict = toolD_map[cmd]  # check on this again
 
-        if all_yes(a_dict_child):
-            if cmd in toolC_updated_map:
-                toolC_updated_map[cmd][key] = new_clean_dict
-            else:
-                toolC_updated_map[cmd] = {key: new_clean_dict}
-            continue
-        new_clean_dict.pop("comparison", None)
-        comparison_dict = toolD_map[cmd]  # check on this again
-
-        valid_dict = {}
-        valid_dict[key] = {}
-        valid_dict[key]["filters"] = new_clean_dict
-        valid_dict[key]["filters"].update(comparison_dict)
-        toolC_updated_map[cmd] = valid_dict  # only gets populated if filters exist
-pprint(toolC_updated_map)
+            valid_dict = {}
+            valid_dict[key] = {}
+            valid_dict[key]["filters"] = new_clean_dict
+            valid_dict[key]["filters"].update(comparison_dict)
+            toolC_updated_map[cmd] = valid_dict  # only gets populated if filters exist
+    pprint(toolC_updated_map)
 
 
-print(len(toolC_updated_map.keys()))
-print(len(toolC_map.keys()))
+    print(len(toolC_updated_map.keys()))
+    print(len(toolC_map.keys()))
 
-# output of tool 1
-folder_name_A = parent_folder + "A/"
-tool_A_out_file = folder_name_A + "all_agreements.txt"
-
-# output of tool 2
-folder_name_B = parent_folder + "B/"
-tool_B_out_file = folder_name_B + "all_agreements.txt"
-
-# combine outputs
-# check if all keys of t1 annotated yes -> put directly
-# if no , check child in t2 and combine
-# construct mape of tool 1
-toolA_map = {}
-with open(tool_A_out_file) as f:
-    for line in f.readlines():
-        line = line.strip()
-        cmd, a_d = line.split("\t")
-        toolA_map[cmd] = a_d
-print(len(toolA_map.keys()))
-
-# construct map of tool 2
-toolB_map = {}
-
-if path.isfile(tool_B_out_file):
-    with open(tool_B_out_file) as f2:
-        for line in f2.readlines():
+    # combine outputs
+    # check if all keys of t1 annotated yes -> put directly
+    # if no , check child in t2 and combine
+    # construct mape of tool 1
+    with open(tool_A_out_file) as f:
+        for line in f.readlines():
             line = line.strip()
-            cmd, child, child_dict = line.split("\t")
-            if cmd in toolB_map and child in toolB_map[cmd]:
-                print("BUGGG")
-            if cmd not in toolB_map:
-                toolB_map[cmd] = {}
-            toolB_map[cmd][child] = child_dict
-print(len(toolB_map.keys()))
+            cmd, a_d = line.split("\t")
+            toolA_map[cmd] = a_d
+    print(len(toolA_map.keys()))
+
+    # construct map of tool 2
+
+    if os.path.isfile(tool_B_out_file):
+        with open(tool_B_out_file) as f2:
+            for line in f2.readlines():
+                line = line.strip()
+                cmd, child, child_dict = line.split("\t")
+                if cmd in toolB_map and child in toolB_map[cmd]:
+                    print("BUGGG")
+                if cmd not in toolB_map:
+                    toolB_map[cmd] = {}
+                toolB_map[cmd][child] = child_dict
+    print(len(toolB_map.keys()))
 
 
 def all_yes(a_dict):
@@ -262,89 +244,111 @@ def fix_spans(d):
     return new_d
 
 
-# combine and write output to a file
-i = 0
-# what these action will look like in the map
-dance_type_map = {"point": "point", "look": "look_turn", "turn": "body_turn"}
+def update_action_dictionaries(all_combined_path):
+    # combine and write output to a file
+    i = 0
+    # what these action will look like in the map
+    dance_type_map = {"point": "point", "look": "look_turn", "turn": "body_turn"}
 
-# update dict of tool1 with tool 2
-with open(parent_folder + "/all_combined.txt", "w") as f:
-    for cmd, a_dict in toolA_map.items():
-        # remove the ['yes', val] etc
-        clean_dict = clean_dict_1(a_dict)
-        print(clean_dict)
-        if all_yes(a_dict):
-            action_type = clean_dict["action_type"]
+    # update dict of tool1 with tool 2
+    with open(all_combined_path, "w") as f:
+        for cmd, a_dict in toolA_map.items():
+            # remove the ['yes', val] etc
+            clean_dict = clean_dict_1(a_dict)
+            print(clean_dict)
+            if all_yes(a_dict):
+                action_type = clean_dict["action_type"]
+
+                valid_dict = {}
+                valid_dict["dialogue_type"] = clean_dict["dialogue_type"]
+                del clean_dict["dialogue_type"]
+                clean_dict["action_type"] = clean_dict["action_type"].upper()
+                act_dict = fix_spans(clean_dict)
+                valid_dict["action_sequence"] = [act_dict]
+
+                f.write(cmd + "\t" + json.dumps(valid_dict) + "\n")
+                print(cmd)
+                print(valid_dict)
+                print("All yes")
+                print("*" * 20)
+                continue
+            if clean_dict["action_type"] == "noop":
+                f.write(cmd + "\t" + json.dumps(clean_dict) + "\n")
+                print(clean_dict)
+                print("NOOP")
+                print("*" * 20)
+                continue
+            if clean_dict["action_type"] == "otheraction":
+                f.write(cmd + "\t" + str(a_dict) + "\n")
+                continue
+
+            if toolB_map and cmd in toolB_map:
+                child_dict_all = toolB_map[cmd]
+                # update action dict with all children except for reference object
+                for k, v in child_dict_all.items():
+                    if k not in clean_dict:
+                        print("BUGGGG")
+                    if type(v) == str:
+                        v = ast.literal_eval(v)
+                    if not v:
+                        continue
+
+                    if "reference_object" in v[k]:
+                        value = v[k]["reference_object"]
+                        v[k]["reference_object"] = fix_ref_obj(value)
+                    if k == "tag_val":
+                        clean_dict.update(v)
+                    elif k == "facing":
+                        action_type = clean_dict["action_type"]
+                        # set to dance
+                        clean_dict["action_type"] = "DANCE"
+                        clean_dict["dance_type"] = {dance_type_map[action_type]: v["facing"]}
+                        clean_dict.pop("facing")
+                    else:
+                        clean_dict[k] = v[k]
+            ref_obj_dict = {}
+            if toolC_updated_map and cmd in toolC_updated_map:
+                ref_obj_dict = toolC_updated_map[cmd]
+            clean_dict.update(ref_obj_dict)
+            if "receiver_reference_object" in clean_dict:
+                clean_dict["receiver"] = {"reference_object": clean_dict["receiver_reference_object"]}
+                clean_dict.pop("receiver_reference_object")
+            if "receiver_location" in clean_dict:
+                clean_dict["receiver"] = {"location": clean_dict["receiver_location"]}
+                clean_dict.pop("receiver_location")
+
+            actual_dict = copy.deepcopy((clean_dict))
+
+            action_type = actual_dict["action_type"]
 
             valid_dict = {}
-            valid_dict["dialogue_type"] = clean_dict["dialogue_type"]
-            del clean_dict["dialogue_type"]
-            clean_dict["action_type"] = clean_dict["action_type"].upper()
-            act_dict = fix_spans(clean_dict)
+            valid_dict["dialogue_type"] = actual_dict["dialogue_type"]
+            del actual_dict["dialogue_type"]
+            actual_dict["action_type"] = actual_dict["action_type"].upper()
+            act_dict = fix_spans(actual_dict)
             valid_dict["action_sequence"] = [act_dict]
-
-            f.write(cmd + "\t" + json.dumps(valid_dict) + "\n")
             print(cmd)
-            print(valid_dict)
-            print("All yes")
-            print("*" * 20)
-            continue
-        if clean_dict["action_type"] == "noop":
-            f.write(cmd + "\t" + json.dumps(clean_dict) + "\n")
-            print(clean_dict)
-            print("NOOP")
-            print("*" * 20)
-            continue
-        if clean_dict["action_type"] == "otheraction":
-            f.write(cmd + "\t" + str(a_dict) + "\n")
-            continue
+            pprint(valid_dict)
+            print("*" * 40)
+            f.write(cmd + "\t" + json.dumps(valid_dict) + "\n")
 
-        if toolB_map and cmd in toolB_map:
-            child_dict_all = toolB_map[cmd]
-            # update action dict with all children except for reference object
-            for k, v in child_dict_all.items():
-                if k not in clean_dict:
-                    print("BUGGGG")
-                if type(v) == str:
-                    v = ast.literal_eval(v)
-                if not v:
-                    continue
 
-                if "reference_object" in v[k]:
-                    value = v[k]["reference_object"]
-                    v[k]["reference_object"] = fix_ref_obj(value)
-                if k == "tag_val":
-                    clean_dict.update(v)
-                elif k == "facing":
-                    action_type = clean_dict["action_type"]
-                    # set to dance
-                    clean_dict["action_type"] = "DANCE"
-                    clean_dict["dance_type"] = {dance_type_map[action_type]: v["facing"]}
-                    clean_dict.pop("facing")
-                else:
-                    clean_dict[k] = v[k]
-        ref_obj_dict = {}
-        if toolC_updated_map and cmd in toolC_updated_map:
-            ref_obj_dict = toolC_updated_map[cmd]
-        clean_dict.update(ref_obj_dict)
-        if "receiver_reference_object" in clean_dict:
-            clean_dict["receiver"] = {"reference_object": clean_dict["receiver_reference_object"]}
-            clean_dict.pop("receiver_reference_object")
-        if "receiver_location" in clean_dict:
-            clean_dict["receiver"] = {"location": clean_dict["receiver_location"]}
-            clean_dict.pop("receiver_location")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
 
-        actual_dict = copy.deepcopy((clean_dict))
+    # Default to directory of script being run for writing inputs and outputs
+    default_write_dir = os.path.dirname(os.path.abspath(__file__))
+    
+    parser.add_argument("--write_dir_path", type=str, default=default_write_dir)
+    args = parser.parse_args()
 
-        action_type = actual_dict["action_type"]
+    # This must exist since we are using tool A outputs
+    folder_name_A = '{}/A/all_agreements.txt'.format(args.write_dir_path)
+    folder_name_B = '{}/B/all_agreements.txt'.format(args.write_dir_path)
+    folder_name_C = '{}/C/all_agreements.txt'.format(args.write_dir_path)
+    folder_name_D = '{}/D/all_agreements.txt'.format(args.write_dir_path)
+    all_combined_path = '{}/all_combined.txt'.format(args.write_dir_path)
 
-        valid_dict = {}
-        valid_dict["dialogue_type"] = actual_dict["dialogue_type"]
-        del actual_dict["dialogue_type"]
-        actual_dict["action_type"] = actual_dict["action_type"].upper()
-        act_dict = fix_spans(actual_dict)
-        valid_dict["action_sequence"] = [act_dict]
-        print(cmd)
-        pprint(valid_dict)
-        print("*" * 40)
-        f.write(cmd + "\t" + json.dumps(valid_dict) + "\n")
+    collect_tool_outputs(folder_name_C, folder_name_D)
+    combine_and_write_outputs(folder_name_A, folder_name_B)
+    update_action_dictionaries(all_combined_path)

--- a/tools/annotation_tools/turk_with_s3/create_jobs.py
+++ b/tools/annotation_tools/turk_with_s3/create_jobs.py
@@ -76,10 +76,10 @@ def create_turk_job(xml_file_path: str, tool_num: int):
             print(curr_question)
 
             new_hit = mturk.create_hit(
-                Title="Match Sentences",
-                Description="Given an original sentence, identify whether new sentences have the same structure as the original.",
+                Title="CraftAssist Instruction Annotations",
+                Description="Given a sentence, provide information about its intent and highlight key words",
                 Keywords="text, categorization, quick",
-                Reward="0.15",
+                Reward="1.0",
                 MaxAssignments=1,
                 LifetimeInSeconds=600,
                 AssignmentDurationInSeconds=600,

--- a/tools/annotation_tools/turk_with_s3/generate_input_for_tool_B_and_C.py
+++ b/tools/annotation_tools/turk_with_s3/generate_input_for_tool_B_and_C.py
@@ -1,0 +1,74 @@
+"""
+Construct input for annotation tools B and C from tool A outputs.
+"""
+folder_name_A = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/A/' 
+folder_name_B = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/B/'
+folder_name_C = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/C/'
+
+tool_A_out_file = folder_name_A + 'all_agreements.txt'
+tool_B_input_file = folder_name_B + 'input.txt'
+tool_C_input_file = folder_name_C + 'input.txt'
+
+from pprint import pprint
+import ast
+import json
+import copy
+
+example_d = {}
+
+def merge_indices(indices):
+    a, b = indices[0]
+    for i in range(1, len(indices)):
+        x, y = indices[i]
+        if x != b + 1:
+            return indices
+        else:
+            b = y
+    if a==b:
+        return a
+    return [a, b]
+
+
+all_actions = {}
+composites= []
+with open(tool_A_out_file, "r") as f1, open(tool_B_input_file, 'w') as f2, open(tool_C_input_file, 'w') as f3:
+    
+    for line in f1.readlines():
+        line  = line.strip()
+        cmd, out = line.split("\t")
+        words = cmd.split()
+        
+        words_copy = copy.deepcopy(words)
+        action_dict = ast.literal_eval(out)
+        action_type = action_dict['action_type'][1]
+        
+        all_actions[action_type] =  all_actions.get(action_type, 0)+ 1
+        # write composite separately
+        # NOTE: not currently using composites in annotations pipeline
+        if action_type=='composite_action':
+            composites.append(" ".join(words))
+            continue
+         
+        # no need to annotate children of these two actions
+        if action_type == 'noop':
+            continue
+            
+        # find children that need to be re-annotated
+        for key, val in action_dict.items():
+            child_name = None
+            # child needs annotation
+            if val[0]== 'no':
+                # insert "span"
+                words_copy = copy.deepcopy(words)
+                child_name = key           
+                indices = merge_indices(val[1])
+                span_text = None
+                line_output = "{}\t{}\t{}\t{}\t{}".format(" ".join(words), " ".join(words), action_type, child_name, [indices])
+                if child_name in ['reference_object', 
+                                  'receiver_reference_object', 
+                                  'source_reference_object']:
+                    # write for tool C 
+                    f3.write(line_output + "\n")
+                else:
+                    # write for tool B
+                    f2.write(line_output + "\n")

--- a/tools/annotation_tools/turk_with_s3/generate_input_for_tool_B_and_C.py
+++ b/tools/annotation_tools/turk_with_s3/generate_input_for_tool_B_and_C.py
@@ -1,20 +1,13 @@
 """
 Construct input for annotation tools B and C from tool A outputs.
 """
-folder_name_A = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/A/' 
-folder_name_B = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/B/'
-folder_name_C = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/C/'
-
-tool_A_out_file = folder_name_A + 'all_agreements.txt'
-tool_B_input_file = folder_name_B + 'input.txt'
-tool_C_input_file = folder_name_C + 'input.txt'
-
 from pprint import pprint
 import ast
 import json
 import copy
+import argparse
+import os
 
-example_d = {}
 
 def merge_indices(indices):
     a, b = indices[0]
@@ -29,46 +22,75 @@ def merge_indices(indices):
     return [a, b]
 
 
-all_actions = {}
-composites= []
-with open(tool_A_out_file, "r") as f1, open(tool_B_input_file, 'w') as f2, open(tool_C_input_file, 'w') as f3:
-    
-    for line in f1.readlines():
-        line  = line.strip()
-        cmd, out = line.split("\t")
-        words = cmd.split()
+def construct_inputs_from_tool_A(tool_A_out_file, tool_B_input_file, tool_C_input_file):
+    all_actions = {}
+    composites= []
+    with open(tool_A_out_file, "r") as f1, open(tool_B_input_file, 'w') as f2, open(tool_C_input_file, 'w') as f3:
         
-        words_copy = copy.deepcopy(words)
-        action_dict = ast.literal_eval(out)
-        action_type = action_dict['action_type'][1]
-        
-        all_actions[action_type] =  all_actions.get(action_type, 0)+ 1
-        # write composite separately
-        # NOTE: not currently using composites in annotations pipeline
-        if action_type=='composite_action':
-            composites.append(" ".join(words))
-            continue
-         
-        # no need to annotate children of these two actions
-        if action_type == 'noop':
-            continue
+        for line in f1.readlines():
+            line  = line.strip()
+            cmd, out = line.split("\t")
+            words = cmd.split()
             
-        # find children that need to be re-annotated
-        for key, val in action_dict.items():
-            child_name = None
-            # child needs annotation
-            if val[0]== 'no':
-                # insert "span"
-                words_copy = copy.deepcopy(words)
-                child_name = key           
-                indices = merge_indices(val[1])
-                span_text = None
-                line_output = "{}\t{}\t{}\t{}\t{}".format(" ".join(words), " ".join(words), action_type, child_name, [indices])
-                if child_name in ['reference_object', 
-                                  'receiver_reference_object', 
-                                  'source_reference_object']:
-                    # write for tool C 
-                    f3.write(line_output + "\n")
-                else:
-                    # write for tool B
-                    f2.write(line_output + "\n")
+            words_copy = copy.deepcopy(words)
+            action_dict = ast.literal_eval(out)
+            action_type = action_dict['action_type'][1]
+            
+            all_actions[action_type] =  all_actions.get(action_type, 0)+ 1
+            # write composite separately
+            # NOTE: not currently using composites in annotations pipeline
+            if action_type=='composite_action':
+                composites.append(" ".join(words))
+                continue
+            
+            # no need to annotate children of these two actions
+            if action_type == 'noop':
+                continue
+                
+            # find children that need to be re-annotated
+            for key, val in action_dict.items():
+                child_name = None
+                # child needs annotation
+                if val[0]== 'no':
+                    # insert "span"
+                    words_copy = copy.deepcopy(words)
+                    child_name = key           
+                    indices = merge_indices(val[1])
+                    span_text = None
+                    line_output = "{}\t{}\t{}\t{}\t{}".format(" ".join(words), " ".join(words), action_type, child_name, [indices])
+                    if child_name in ['reference_object', 
+                                    'receiver_reference_object', 
+                                    'source_reference_object']:
+                        # write for tool C 
+                        f3.write(line_output + "\n")
+                    else:
+                        # write for tool B
+                        f2.write(line_output + "\n")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    # Default to directory of script being run for writing inputs and outputs
+    default_write_dir = os.path.dirname(os.path.abspath(__file__))
+    
+    parser.add_argument("--write_dir_path", type=str, default=default_write_dir)
+    args = parser.parse_args()
+
+    # This must exist since we are using tool A outputs
+    folder_name_A = '{}/A/'.format(args.write_dir_path)
+    # Directories for tools B and C may not exist yet
+    folder_name_B = '{}/B/'.format(args.write_dir_path)
+    folder_name_C = '{}/C/'.format(args.write_dir_path)
+
+    # If the tool specific write directories do not exist, create them
+    if not os.path.isdir(folder_name_B):
+        os.mkdir(folder_name_B)
+
+    if not os.path.isdir(folder_name_C):
+        os.mkdir(folder_name_C)
+
+    tool_A_out_file = folder_name_A + 'all_agreements.txt'
+    tool_B_input_file = folder_name_B + 'input.txt'
+    tool_C_input_file = folder_name_C + 'input.txt'
+
+    construct_inputs_from_tool_A(tool_A_out_file, tool_B_input_file, tool_C_input_file)

--- a/tools/annotation_tools/turk_with_s3/generate_input_for_tool_D.py
+++ b/tools/annotation_tools/turk_with_s3/generate_input_for_tool_D.py
@@ -1,5 +1,8 @@
 """
-Construct input for annotation tools B and C from tool A outputs.
+Construct input for annotation tools D from tool C outputs.
+
+inpout for tool D is : 
+text \t \text \t "reference_object" \t "comparison" \t highlighted_text
 """
 from pprint import pprint
 import ast
@@ -8,22 +11,12 @@ import copy
 import argparse
 import os
 
-
-# construct input for tool D from tool C's output
-# inpout for tool D is : 
-# text \t highlighted_text \t "reference_object" \t "comparison"
-# folder_name_C = '../../minecraft/python/craftassist/text_to_tree_tool/turk_data/new_dance_form_data/next_20/tool3/'
-# folder_name_D = '../../minecraft/python/craftassist/text_to_tree_tool/turk_data/new_dance_form_data/next_20/tool4/'
-folder_name_C = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/C/' #'/Users/kavyasrinet/Desktop/other_actions/0/toolC/'
-folder_name_D = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/D/' #'/Users/kavyasrinet/Desktop/other_actions/0/toolD/'
+folder_name_C = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/C/'
+folder_name_D = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/D/'
 tool_C_out_file = folder_name_C + 'all_agreements.txt'
 tool_D_input_file = folder_name_D + 'input.txt'
 
 from pprint import pprint
-'''
-command: Input.command
-
-'''
 import copy
 example_d = {}
 
@@ -33,7 +26,6 @@ def merge_indices(indices):
         x, y = indices[i]
         if x != b + 1:
             return indices
-            # raise NotImplementedError("Spans not continuous during merging!!!")
         else:
             b = y
     if a==b:
@@ -61,9 +53,6 @@ with open(tool_C_out_file, "r") as f1, open(tool_D_input_file, 'w') as f2:
             continue
         out_dict = json.loads(out)
         ref_obj_dict = out_dict[action_child_name]
-#         print(out_dict)
-#         print(ref_obj_dict)
-#         break
             
         # find children that need to be re-annotated
         for key, val in ref_obj_dict.items():
@@ -76,23 +65,14 @@ with open(tool_C_out_file, "r") as f1, open(tool_D_input_file, 'w') as f2:
                 
                 write_line = ""
                 write_line += " ".join(words) + "\t"
-                #print(words, child_name, action_type, val[1])
                 
-                indices = merge_indices(val[1])
-                span_text = None
-                if type(indices) == list:
-                    if type(indices[0]) == list:
-                        # this means that indices were scattered and disjoint
-                        for idx in indices:
-                            words_copy[idx[0]] = "<span style='background-color: #FFFF00'>" + words_copy[idx[0]]
-                            words_copy[idx[1]] = words_copy[idx[1]] + "</span>"
-                    else:
-                        words_copy[indices[0]] = "<span style='background-color: #FFFF00'>" + words_copy[indices[0]]
-                        words_copy[indices[1]] = words_copy[indices[1]] + "</span>"
+                if len(val[1]) > 1:
+                    indices = merge_indices(val[1])
                 else:
-                    words_copy[indices] = "<span style='background-color: #FFFF00'>" + words_copy[indices] + "</span>"
-                write_line += " ".join(words_copy) + "\t" + action_child_name + "\t" + child_name
-                f2.write(write_line+ "\n")
+                    indices = val[1]
+                
+                line_output = "{}\t{}\t{}\t{}\t{}".format(" ".join(words), " ".join(words), action_child_name, child_name, str(indices).replace(", ","-"))
+                f2.write(line_output+ "\n")
 
 # if __name__ == "__main__":
 #     parser = argparse.ArgumentParser()

--- a/tools/annotation_tools/turk_with_s3/generate_input_for_tool_D.py
+++ b/tools/annotation_tools/turk_with_s3/generate_input_for_tool_D.py
@@ -1,0 +1,123 @@
+"""
+Construct input for annotation tools B and C from tool A outputs.
+"""
+from pprint import pprint
+import ast
+import json
+import copy
+import argparse
+import os
+
+
+# construct input for tool D from tool C's output
+# inpout for tool D is : 
+# text \t highlighted_text \t "reference_object" \t "comparison"
+# folder_name_C = '../../minecraft/python/craftassist/text_to_tree_tool/turk_data/new_dance_form_data/next_20/tool3/'
+# folder_name_D = '../../minecraft/python/craftassist/text_to_tree_tool/turk_data/new_dance_form_data/next_20/tool4/'
+folder_name_C = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/C/' #'/Users/kavyasrinet/Desktop/other_actions/0/toolC/'
+folder_name_D = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/D/' #'/Users/kavyasrinet/Desktop/other_actions/0/toolD/'
+tool_C_out_file = folder_name_C + 'all_agreements.txt'
+tool_D_input_file = folder_name_D + 'input.txt'
+
+from pprint import pprint
+'''
+command: Input.command
+
+'''
+import copy
+example_d = {}
+
+def merge_indices(indices):
+    a, b = indices[0]
+    for i in range(1, len(indices)):
+        x, y = indices[i]
+        if x != b + 1:
+            return indices
+            # raise NotImplementedError("Spans not continuous during merging!!!")
+        else:
+            b = y
+    if a==b:
+        return a
+    return [a, b]
+import ast
+import json
+
+
+all_actions = {}
+with open(tool_C_out_file, "r") as f1, open(tool_D_input_file, 'w') as f2:
+    composites= []
+    
+    for line in f1.readlines():
+        line  = line.strip()
+        cmd, action_child_name , out = line.split("\t")
+        words = cmd.split()
+        
+        words_copy = copy.deepcopy(words)
+        #pprint(out)
+        if action_child_name not in ['reference_object', 
+                                     'receiver_reference_object',
+                                     'source_reference_object']:
+            print("Not a reference object!!!")
+            continue
+        out_dict = json.loads(out)
+        ref_obj_dict = out_dict[action_child_name]
+#         print(out_dict)
+#         print(ref_obj_dict)
+#         break
+            
+        # find children that need to be re-annotated
+        for key, val in ref_obj_dict.items():
+            child_name = None
+            # child needs annotation
+            if val[0]== 'no':
+                # insert "span"
+                words_copy = copy.deepcopy(words)
+                child_name = key
+                
+                write_line = ""
+                write_line += " ".join(words) + "\t"
+                #print(words, child_name, action_type, val[1])
+                
+                indices = merge_indices(val[1])
+                span_text = None
+                if type(indices) == list:
+                    if type(indices[0]) == list:
+                        # this means that indices were scattered and disjoint
+                        for idx in indices:
+                            words_copy[idx[0]] = "<span style='background-color: #FFFF00'>" + words_copy[idx[0]]
+                            words_copy[idx[1]] = words_copy[idx[1]] + "</span>"
+                    else:
+                        words_copy[indices[0]] = "<span style='background-color: #FFFF00'>" + words_copy[indices[0]]
+                        words_copy[indices[1]] = words_copy[indices[1]] + "</span>"
+                else:
+                    words_copy[indices] = "<span style='background-color: #FFFF00'>" + words_copy[indices] + "</span>"
+                write_line += " ".join(words_copy) + "\t" + action_child_name + "\t" + child_name
+                f2.write(write_line+ "\n")
+
+# if __name__ == "__main__":
+#     parser = argparse.ArgumentParser()
+
+#     # Default to directory of script being run for writing inputs and outputs
+#     default_write_dir = os.path.dirname(os.path.abspath(__file__))
+    
+#     parser.add_argument("--write_dir_path", type=str, default=default_write_dir)
+#     args = parser.parse_args()
+
+#     # This must exist since we are using tool A outputs
+#     folder_name_A = '{}/A/'.format(args.write_dir_path)
+#     # Directories for tools B and C may not exist yet
+#     folder_name_B = '{}/B/'.format(args.write_dir_path)
+#     folder_name_C = '{}/C/'.format(args.write_dir_path)
+
+#     # If the tool specific write directories do not exist, create them
+#     if not os.path.isdir(folder_name_B):
+#         os.mkdir(folder_name_B)
+
+#     if not os.path.isdir(folder_name_C):
+#         os.mkdir(folder_name_C)
+
+#     tool_A_out_file = folder_name_A + 'all_agreements.txt'
+#     tool_B_input_file = folder_name_B + 'input.txt'
+#     tool_C_input_file = folder_name_C + 'input.txt'
+
+#     construct_inputs_from_tool_A(tool_A_out_file, tool_B_input_file, tool_C_input_file)

--- a/tools/annotation_tools/turk_with_s3/generate_input_for_tool_D.py
+++ b/tools/annotation_tools/turk_with_s3/generate_input_for_tool_D.py
@@ -10,15 +10,8 @@ import json
 import copy
 import argparse
 import os
-
-folder_name_C = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/C/'
-folder_name_D = '/private/home/rebeccaqian/droidlet/tools/annotation_tools/turk_with_s3/D/'
-tool_C_out_file = folder_name_C + 'all_agreements.txt'
-tool_D_input_file = folder_name_D + 'input.txt'
-
 from pprint import pprint
 import copy
-example_d = {}
 
 def merge_indices(indices):
     a, b = indices[0]
@@ -35,69 +28,65 @@ import ast
 import json
 
 
-all_actions = {}
-with open(tool_C_out_file, "r") as f1, open(tool_D_input_file, 'w') as f2:
-    composites= []
-    
-    for line in f1.readlines():
-        line  = line.strip()
-        cmd, action_child_name , out = line.split("\t")
-        words = cmd.split()
+def construct_inputs_from_tool_C(tool_C_out_file, tool_D_input_file):
+    all_actions = {}
+    with open(tool_C_out_file, "r") as f1, open(tool_D_input_file, 'w') as f2:
+        composites= []
         
-        words_copy = copy.deepcopy(words)
-        #pprint(out)
-        if action_child_name not in ['reference_object', 
-                                     'receiver_reference_object',
-                                     'source_reference_object']:
-            print("Not a reference object!!!")
-            continue
-        out_dict = json.loads(out)
-        ref_obj_dict = out_dict[action_child_name]
+        for line in f1.readlines():
+            line  = line.strip()
+            cmd, action_child_name , out = line.split("\t")
+            words = cmd.split()
             
-        # find children that need to be re-annotated
-        for key, val in ref_obj_dict.items():
-            child_name = None
-            # child needs annotation
-            if val[0]== 'no':
-                # insert "span"
-                words_copy = copy.deepcopy(words)
-                child_name = key
+            words_copy = copy.deepcopy(words)
+            #pprint(out)
+            if action_child_name not in ['reference_object', 
+                                        'receiver_reference_object',
+                                        'source_reference_object']:
+                print("Not a reference object!!!")
+                continue
+            out_dict = json.loads(out)
+            ref_obj_dict = out_dict[action_child_name]
                 
-                write_line = ""
-                write_line += " ".join(words) + "\t"
-                
-                if len(val[1]) > 1:
-                    indices = merge_indices(val[1])
-                else:
-                    indices = val[1]
-                
-                line_output = "{}\t{}\t{}\t{}\t{}".format(" ".join(words), " ".join(words), action_child_name, child_name, str(indices).replace(", ","-"))
-                f2.write(line_output+ "\n")
+            # find children that need to be re-annotated
+            for key, val in ref_obj_dict.items():
+                child_name = None
+                # child needs annotation
+                if val[0]== 'no':
+                    # insert "span"
+                    words_copy = copy.deepcopy(words)
+                    child_name = key
+                    
+                    write_line = ""
+                    write_line += " ".join(words) + "\t"
+                    
+                    if len(val[1]) > 1:
+                        indices = [merge_indices(val[1])]
+                    else:
+                        indices = val[1]
+                    
+                    line_output = "{}\t{}\t{}\t{}\t{}".format(" ".join(words), " ".join(words), action_child_name, child_name, str(indices).replace(", ","-"))
+                    f2.write(line_output+ "\n")
 
-# if __name__ == "__main__":
-#     parser = argparse.ArgumentParser()
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
 
-#     # Default to directory of script being run for writing inputs and outputs
-#     default_write_dir = os.path.dirname(os.path.abspath(__file__))
+    # Default to directory of script being run for writing inputs and outputs
+    default_write_dir = os.path.dirname(os.path.abspath(__file__))
     
-#     parser.add_argument("--write_dir_path", type=str, default=default_write_dir)
-#     args = parser.parse_args()
+    parser.add_argument("--write_dir_path", type=str, default=default_write_dir)
+    args = parser.parse_args()
 
-#     # This must exist since we are using tool A outputs
-#     folder_name_A = '{}/A/'.format(args.write_dir_path)
-#     # Directories for tools B and C may not exist yet
-#     folder_name_B = '{}/B/'.format(args.write_dir_path)
-#     folder_name_C = '{}/C/'.format(args.write_dir_path)
+    # This must exist since we are using tool A outputs
+    folder_name_C = '{}/C/'.format(args.write_dir_path)
+    # Directories for tool D may not exist yet
+    folder_name_D = '{}/D/'.format(args.write_dir_path)
 
-#     # If the tool specific write directories do not exist, create them
-#     if not os.path.isdir(folder_name_B):
-#         os.mkdir(folder_name_B)
+    # If the tool specific write directories do not exist, create them
+    if not os.path.isdir(folder_name_D):
+        os.mkdir(folder_name_D)
 
-#     if not os.path.isdir(folder_name_C):
-#         os.mkdir(folder_name_C)
+    tool_C_out_file = folder_name_C + 'all_agreements.txt'
+    tool_D_input_file = folder_name_D + 'input.txt'
 
-#     tool_A_out_file = folder_name_A + 'all_agreements.txt'
-#     tool_B_input_file = folder_name_B + 'input.txt'
-#     tool_C_input_file = folder_name_C + 'input.txt'
-
-#     construct_inputs_from_tool_A(tool_A_out_file, tool_B_input_file, tool_C_input_file)
+    construct_inputs_from_tool_C(tool_C_out_file, tool_D_input_file)

--- a/tools/annotation_tools/turk_with_s3/parse_tool_A_outputs.py
+++ b/tools/annotation_tools/turk_with_s3/parse_tool_A_outputs.py
@@ -15,6 +15,7 @@ from spacy.lang.en import English
 from typing import List
 from operator import itemgetter
 from pprint import pprint
+import os
 
 
 def word_tokenize(st) -> str:
@@ -509,9 +510,12 @@ def resolve_spans(words, dicts):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    # Default to directory of script being run for writing inputs and outputs
+    default_write_dir = os.path.dirname(os.path.abspath(__file__))
+
     parser.add_argument(
         "--folder_name",
-        default="/Users/rebeccaqian/minecraft/tools/annotation_tools/turk_with_s3/A/",
+        default="{}/A/".format(default_write_dir),
     )
     opts = parser.parse_args()
     print(opts)

--- a/tools/annotation_tools/turk_with_s3/parse_tool_C_outputs.py
+++ b/tools/annotation_tools/turk_with_s3/parse_tool_C_outputs.py
@@ -6,6 +6,7 @@ import re
 from operator import itemgetter
 from pprint import pprint
 import ast
+import os
 
 MAX_WORDS = 40
 
@@ -471,9 +472,12 @@ def resolve_spans(words, dicts):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    # Default to directory of script being run for writing inputs and outputs
+    default_write_dir = os.path.dirname(os.path.abspath(__file__))
+
     parser.add_argument(
         "--folder_name",
-        default="/Users/rebeccaqian/minecraft/tools/annotation_tools/turk_with_s3/C/",
+        default="{}/C/".format(default_write_dir),
     )
     opts = parser.parse_args()
     folder_name = opts.folder_name

--- a/tools/annotation_tools/turk_with_s3/parse_tool_D_outputs.py
+++ b/tools/annotation_tools/turk_with_s3/parse_tool_D_outputs.py
@@ -6,7 +6,7 @@ from operator import itemgetter
 import json
 import ast
 from pprint import pprint
-
+import os
 
 def remove_prefix(text, prefix):
     if text.startswith(prefix):
@@ -396,10 +396,13 @@ def resolve_spans(words, dicts):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    # Default to directory of script being run for writing inputs and outputs
+    default_write_dir = os.path.dirname(os.path.abspath(__file__))
+    
     parser.add_argument(
         "--folder_name",
         type=str,
-        default="/Users/rebeccaqian/minecraft/tools/annotation_tools/turk_with_s3/D/",
+        default="{}/D/".format(default_write_dir),
     )
     opts = parser.parse_args()
     # convert csv to txt

--- a/tools/annotation_tools/turk_with_s3/postprocess_part_B.py
+++ b/tools/annotation_tools/turk_with_s3/postprocess_part_B.py
@@ -6,6 +6,7 @@ from operator import itemgetter
 import ast
 from pprint import pprint
 import json
+import os
 
 
 def process_repeat_dict(d):
@@ -528,9 +529,11 @@ def resolve_spans(words, dicts):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    # Default to directory of script being run for writing inputs and outputs
+    default_write_dir = os.path.dirname(os.path.abspath(__file__))
     parser.add_argument(
         "--folder_name",
-        default="/Users/rebeccaqian/minecraft/tools/annotation_tools/turk_with_s3/",
+        default="{}/".format(default_write_dir),
     )
     opts = parser.parse_args()
 

--- a/tools/annotation_tools/turk_with_s3/run_all_tasks.py
+++ b/tools/annotation_tools/turk_with_s3/run_all_tasks.py
@@ -1,6 +1,7 @@
 import subprocess
 import time
 import sys
+import os
 
 """
 Kicks off a pipeline that schedules Turk jobs for tool 1A,
@@ -23,24 +24,33 @@ if rc != 0:
     print("Error preprocessing. Exiting.")
     sys.exit()
 
-# Load input commands and create a separate HIT for each row
-rc = subprocess.call(["python3 run_tool_1B.py"], shell=True)
-if rc != 0:
-    print("Error creating HIT jobs. Exiting.")
-    sys.exit()
-# Wait for results to be ready
-print("Turk jobs created at : %s \n Waiting for results..." % time.ctime())
+# If the tool B input file is not empty, kick off a job
+filesize = os.path.getsize("B/input.txt")
+if filesize > 0:
+    # Load input commands and create a separate HIT for each row
+    rc = subprocess.call(["python3 run_tool_1B.py"], shell=True)
+    if rc != 0:
+        print("Error creating HIT jobs. Exiting.")
+        sys.exit()
+    # Wait for results to be ready
+    print("Turk jobs created at : %s \n Waiting for results..." % time.ctime())
 
 time.sleep(100)
-# Check if results are ready
-rc = subprocess.call(["python3 run_tool_1C.py"], shell=True)
-if rc != 0:
-    print("Error fetching HIT results. Exiting.")
-    sys.exit()
+# If the tool C input file is not empty, kick off a job
+filesize = os.path.getsize("C/input.txt")
+if filesize > 0:
+    # Check if results are ready
+    rc = subprocess.call(["python3 run_tool_1C.py"], shell=True)
+    if rc != 0:
+        print("Error fetching HIT results. Exiting.")
+        sys.exit()
 
-# Collate datasets
-print("*** Collating turk outputs and input job specs ***")
-rc = subprocess.call(["python3 run_tool_1D.py"], shell=True)
-if rc != 0:
-    print("Error collating answers. Exiting.")
-    sys.exit()
+# If the tool B input file is not empty, kick off a job
+filesize = os.path.getsize("D/input.txt")
+if filesize > 0:
+    # Collate datasets
+    print("*** Collating turk outputs and input job specs ***")
+    rc = subprocess.call(["python3 run_tool_1D.py"], shell=True)
+    if rc != 0:
+        print("Error collating answers. Exiting.")
+        sys.exit()

--- a/tools/annotation_tools/turk_with_s3/run_all_tasks.py
+++ b/tools/annotation_tools/turk_with_s3/run_all_tasks.py
@@ -54,3 +54,9 @@ if filesize > 0:
     if rc != 0:
         print("Error collating answers. Exiting.")
         sys.exit()
+
+# Run final postprocessing on the action dictionaries to construct logical forms in sync with grammar
+rc = subprocess.call(["python3 construct_final_action_dict.py"], shell=True)
+if rc != 0:
+    print("Error constructing final dictionary. Exiting.")
+    sys.exit()

--- a/tools/annotation_tools/turk_with_s3/run_all_tasks.py
+++ b/tools/annotation_tools/turk_with_s3/run_all_tasks.py
@@ -1,0 +1,46 @@
+import subprocess
+import time
+import sys
+
+"""
+Kicks off a pipeline that schedules Turk jobs for tool 1A,
+collects results in batches and collates data.
+
+Tool A run finishes
+-> run tool B
+-> run tool C
+-> run tool D
+"""
+
+# CSV input
+rc = subprocess.call(
+    [
+        "python3 run_tool_1A.py"
+    ],
+    shell=True,
+)
+if rc != 0:
+    print("Error preprocessing. Exiting.")
+    sys.exit()
+
+# Load input commands and create a separate HIT for each row
+rc = subprocess.call(["python3 run_tool_1B.py"], shell=True)
+if rc != 0:
+    print("Error creating HIT jobs. Exiting.")
+    sys.exit()
+# Wait for results to be ready
+print("Turk jobs created at : %s \n Waiting for results..." % time.ctime())
+
+time.sleep(100)
+# Check if results are ready
+rc = subprocess.call(["python3 run_tool_1C.py"], shell=True)
+if rc != 0:
+    print("Error fetching HIT results. Exiting.")
+    sys.exit()
+
+# Collate datasets
+print("*** Collating turk outputs and input job specs ***")
+rc = subprocess.call(["python3 run_tool_1D.py"], shell=True)
+if rc != 0:
+    print("Error collating answers. Exiting.")
+    sys.exit()

--- a/tools/annotation_tools/turk_with_s3/run_tool_1A.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1A.py
@@ -52,3 +52,10 @@ rc = subprocess.call(["python parse_outputs.py"], shell=True)
 if rc != 0:
     print("Error collating answers. Exiting.")
     sys.exit()
+
+# Create inputs for other tools
+print("*** Postprocessing results ***")
+rc = subprocess.call(["python generate_input_for_tool_B_and_C.py"], shell=True)
+if rc != 0:
+    print("Error generating input for other tools. Exiting.")
+    sys.exit()

--- a/tools/annotation_tools/turk_with_s3/run_tool_1A.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1A.py
@@ -48,7 +48,7 @@ if rc != 0:
 
 # Postprocess
 print("*** Postprocessing results ***")
-rc = subprocess.call(["python parse_outputs.py"], shell=True)
+rc = subprocess.call(["python parse_tool_A_outputs.py"], shell=True)
 if rc != 0:
     print("Error collating answers. Exiting.")
     sys.exit()

--- a/tools/annotation_tools/turk_with_s3/run_tool_1B.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1B.py
@@ -16,7 +16,7 @@ collects results in batches and collates data.
 # CSV input
 rc = subprocess.call(
     [
-        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file 1B_input.txt --tool_num 2 > turk_input.csv"
+        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file B/input.txt --tool_num 2 > turk_input.csv"
     ],
     shell=True,
 )

--- a/tools/annotation_tools/turk_with_s3/run_tool_1C.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1C.py
@@ -55,3 +55,10 @@ rc = subprocess.call(["python3 parse_tool_C_outputs.py"], shell=True)
 if rc != 0:
     print("Error collating answers. Exiting.")
     sys.exit()
+
+# Create inputs for other tools
+print("*** Postprocessing results ***")
+rc = subprocess.call(["python generate_input_for_tool_D.py"], shell=True)
+if rc != 0:
+    print("Error generating input for other tools. Exiting.")
+    sys.exit()

--- a/tools/annotation_tools/turk_with_s3/run_tool_1C.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1C.py
@@ -16,7 +16,7 @@ collects results in batches and collates data.
 # CSV input
 rc = subprocess.call(
     [
-        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file 1C_input.txt --tool_num 3 > turk_input.csv"
+        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file C/input.txt --tool_num 3 > turk_input.csv"
     ],
     shell=True,
 )

--- a/tools/annotation_tools/turk_with_s3/run_tool_1D.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1D.py
@@ -16,7 +16,7 @@ collects results in batches and collates data.
 # CSV input
 rc = subprocess.call(
     [
-        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file 1D_input.txt --tool_num 4 > turk_input.csv"
+        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file D/input.txt --tool_num 4 > turk_input.csv"
     ],
     shell=True,
 )


### PR DESCRIPTION
# Description

This PR fully automates the text to tree annotations pipeline so that running a single script `run_all_tasks.py` triggers the annotations pipeline that obtains annotations for different parts of the action dictionary, and finally outputs a logical form.

The steps, in sequential order, are (scripts and outputs are by default in the `turk_with_s3` directory):

- Write commands that need annotating in `input.txt`, newline separated
- Run Tool A:
  - Construct inputs for tool A
  - Run annotation tasks which ask high level questions about the action type/intent, and routes to relevant other tools for more information
  - collect, collate and save to agreements (.txt) file
- Generate inputs for tools B and C based on `all_agreements.txt` output from tool A
- Run Tool B, if needed
  - Construct inputs
  - Run annotation tasks for schematics and location nodes
  - collect, collate, save
- Run Tool C, if needed
  - Construct inputs
  - Run annotation tasks for reference objects
  - collect, collate, save
- Generate inputs for tool D based on outputs of tool C
- Run Tool D, if needed
  - Construct inputs
  - Run annotation tasks for keys and values in filters
  - collect, collate, save

Code Changes
- `run_all_tasks.py`: Schedules all processes in the annotations pipeline
- `generate_input_for_tool_B_and_C.py`: run after tool A finishes to prep inputs to B and C 
- `generate_input_for_tool_D.py`: run after tool C finishes to prep inputs to D
- Replaced paths to my home dir with file directory path
- Added checks for whether the tool needs to be run by checking whether the inputs for that tool were generated in a previous step
- Some general cleanup/changes to filepaths to enable seamless end to end runs

Fixes # (issue)
#447
#446  

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before:
Each part of the pipeline required a manual kick off and there were additional scripts that were not automated like postprocessing, or generating inputs that were dependent on tool outputs between runs. 

After:
One click for command to action dictionary end-to-end.

See demo:
https://drive.google.com/drive/u/0/folders/1UzZuq6I_2mFxNsah5zEZt5jo5XxyLuzJ

# Testing

First input commands you want to annotate in `input.txt` in the `turk_with_s3` directory, one on each line. Then run `python run_all_tasks.py`. Make sure that your S3 keys have Turk scope and prepare to log into the MTurk worker sandbox to complete the tasks.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

