### PR TITLE
[Dashboard in Turk] Annotations pipeline bug fixes

### DIFF
--- a/tools/annotation_tools/text_to_tree_tool/annotation_tool_B.py
+++ b/tools/annotation_tools/text_to_tree_tool/annotation_tool_B.py
@@ -240,7 +240,8 @@ if __name__ == "__main__":
         const queryString = window.location.search;
         console.log(queryString);
         let urlParams = new URLSearchParams(queryString);
-        const highlightRange = urlParams.get('range').split(",").map(Number);
+
+        const highlightRange = JSON.parse(urlParams.get("highlight_words"))[0]
         console.log(highlightRange)
         highlightStart = highlightRange[0]
         highlightEnd = highlightRange[1]

--- a/tools/annotation_tools/turk_with_s3/create_jobs.py
+++ b/tools/annotation_tools/turk_with_s3/create_jobs.py
@@ -21,7 +21,7 @@ mturk = boto3.client(
 print("I have $" + mturk.get_account_balance()["AvailableBalance"] + " in my Sandbox account")
 
 
-def create_turk_job(xml_file_path: str, tool_num: int):
+def create_turk_job(xml_file_path: str, tool_num: int, input_csv: str):
     # Delete HITs
     # For use in dev only
     for item in mturk.list_hits()["HITs"]:
@@ -52,7 +52,7 @@ def create_turk_job(xml_file_path: str, tool_num: int):
     # Where we will save the turk job parameters
     turk_jobs_df = pd.DataFrame()
     # TODO: make this command line arg
-    with open("turk_input.csv", newline="") as csvfile:
+    with open(input_csv, newline="") as csvfile:
         turk_inputs = csv.reader(csvfile, delimiter=",")
         headers = next(turk_inputs, None)
         # Construct the URL query params
@@ -107,6 +107,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--xml_file", type=str, required=True)
     parser.add_argument("--tool_num", type=int, required=True)
+    parser.add_argument("--input_csv", type=str, required=True)
 
     args = parser.parse_args()
-    create_turk_job(args.xml_file, args.tool_num)
+    create_turk_job(args.xml_file, args.tool_num, args.input_csv)

--- a/tools/annotation_tools/turk_with_s3/generate_input_for_tool_B_and_C.py
+++ b/tools/annotation_tools/turk_with_s3/generate_input_for_tool_B_and_C.py
@@ -54,10 +54,14 @@ def construct_inputs_from_tool_A(tool_A_out_file, tool_B_input_file, tool_C_inpu
                 if val[0]== 'no':
                     # insert "span"
                     words_copy = copy.deepcopy(words)
-                    child_name = key           
-                    indices = merge_indices(val[1])
+                    child_name = key
+                    if len(val[1]) > 1:
+                        indices = [merge_indices(val[1])]
+                    else:
+                        indices = val[1]           
+                        # indices = merge_indices(val[1])
                     span_text = None
-                    line_output = "{}\t{}\t{}\t{}\t{}".format(" ".join(words), " ".join(words), action_type, child_name, [indices])
+                    line_output = "{}\t{}\t{}\t{}\t{}".format(" ".join(words), " ".join(words), action_type, child_name, str(indices).replace(", ","-"))
                     if child_name in ['reference_object', 
                                     'receiver_reference_object', 
                                     'source_reference_object']:

--- a/tools/annotation_tools/turk_with_s3/get_results.py
+++ b/tools/annotation_tools/turk_with_s3/get_results.py
@@ -16,6 +16,14 @@ mturk = boto3.client(
     endpoint_url=MTURK_SANDBOX,
 )
 
+def delete_hits(mturk):
+    # Check if there are outstanding assignable or reviewable HITs
+    all_hits = mturk.list_hits()["HITs"]
+    hit_ids = [item["HITId"] for item in all_hits]
+    # This is slow but there's no better way to get the status of pending HITs
+    for hit_id in hit_ids:
+        # Get HIT status
+        mturk.delete_hit(HITId=hit_id)
 
 def get_hit_list_status(mturk):
     # Check if there are outstanding assignable or reviewable HITs
@@ -38,6 +46,8 @@ def get_hit_list_status(mturk):
 
 
 # This will contain the answers
+# delete_hits(mturk)
+# print("deleted all HITs")
 res = pd.DataFrame()
 NUM_TRIES_REMAINING = 5
 curr_hit_status = get_hit_list_status(mturk)

--- a/tools/annotation_tools/turk_with_s3/postprocess_part_B.py
+++ b/tools/annotation_tools/turk_with_s3/postprocess_part_B.py
@@ -533,7 +533,7 @@ if __name__ == "__main__":
     default_write_dir = os.path.dirname(os.path.abspath(__file__))
     parser.add_argument(
         "--folder_name",
-        default="{}/".format(default_write_dir),
+        default="{}/B/".format(default_write_dir),
     )
     opts = parser.parse_args()
 
@@ -541,7 +541,7 @@ if __name__ == "__main__":
     # command: Input.command
     result_dict = {}
     folder_name = opts.folder_name
-    f_name = folder_name + "processed_outputs.csv"
+    f_name = folder_name + "../processed_outputs.csv"
     only_show_disagreements = True
     sentence_mapping = {}
     with open(f_name, "r") as f:

--- a/tools/annotation_tools/turk_with_s3/run_all_tasks.py
+++ b/tools/annotation_tools/turk_with_s3/run_all_tasks.py
@@ -35,7 +35,6 @@ if filesize > 0:
     # Wait for results to be ready
     print("Turk jobs created at : %s \n Waiting for results..." % time.ctime())
 
-time.sleep(100)
 # If the tool C input file is not empty, kick off a job
 filesize = os.path.getsize("C/input.txt")
 if filesize > 0:

--- a/tools/annotation_tools/turk_with_s3/run_tool_1A.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1A.py
@@ -16,7 +16,7 @@ collects results in batches and collates data.
 # CSV input
 rc = subprocess.call(
     [
-        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file input.txt > turk_input.csv"
+        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file input.txt > A/turk_input.csv"
     ],
     shell=True,
 )
@@ -25,7 +25,7 @@ if rc != 0:
     sys.exit()
 
 # Load input commands and create a separate HIT for each row
-rc = subprocess.call(["python create_jobs.py --tool_num 1 --xml_file step_1.xml"], shell=True)
+rc = subprocess.call(["python create_jobs.py --tool_num 1 --xml_file step_1.xml --input_csv A/turk_input.csv"], shell=True)
 if rc != 0:
     print("Error creating HIT jobs. Exiting.")
     sys.exit()

--- a/tools/annotation_tools/turk_with_s3/run_tool_1B.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1B.py
@@ -16,7 +16,7 @@ collects results in batches and collates data.
 # CSV input
 rc = subprocess.call(
     [
-        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file B/input.txt --tool_num 2 > turk_input.csv"
+        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file B/input.txt --tool_num 2 > B/turk_input.csv"
     ],
     shell=True,
 )
@@ -26,7 +26,7 @@ if rc != 0:
 
 # Load input commands and create a separate HIT for each row
 rc = subprocess.call(
-    ["python3 create_jobs.py --xml_file fetch_question_B.xml --tool_num 2"], shell=True
+    ["python3 create_jobs.py --xml_file fetch_question_B.xml --tool_num 2 --input_csv B/turk_input.csv"], shell=True
 )
 if rc != 0:
     print("Error creating HIT jobs. Exiting.")

--- a/tools/annotation_tools/turk_with_s3/run_tool_1C.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1C.py
@@ -16,7 +16,7 @@ collects results in batches and collates data.
 # CSV input
 rc = subprocess.call(
     [
-        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file C/input.txt --tool_num 3 > turk_input.csv"
+        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file C/input.txt --tool_num 3 > C/turk_input.csv"
     ],
     shell=True,
 )
@@ -26,7 +26,7 @@ if rc != 0:
 
 # Load input commands and create a separate HIT for each row
 rc = subprocess.call(
-    ["python3 create_jobs.py --xml_file fetch_question_C.xml --tool_num 3"], shell=True
+    ["python3 create_jobs.py --xml_file fetch_question_C.xml --tool_num 3 --input_csv C/turk_input.csv"], shell=True
 )
 if rc != 0:
     print("Error creating HIT jobs. Exiting.")

--- a/tools/annotation_tools/turk_with_s3/run_tool_1D.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1D.py
@@ -16,7 +16,7 @@ collects results in batches and collates data.
 # CSV input
 rc = subprocess.call(
     [
-        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file D/input.txt --tool_num 4 > turk_input.csv"
+        "python3 ../text_to_tree_tool/construct_input_for_turk.py --input_file D/input.txt --tool_num 4 > D/turk_input.csv"
     ],
     shell=True,
 )
@@ -26,7 +26,7 @@ if rc != 0:
 
 # Load input commands and create a separate HIT for each row
 rc = subprocess.call(
-    ["python3 create_jobs.py --xml_file fetch_question_D.xml --tool_num 4"], shell=True
+    ["python3 create_jobs.py --xml_file fetch_question_D.xml --tool_num 4 --input_csv D/turk_input.csv"], shell=True
 )
 if rc != 0:
     print("Error creating HIT jobs. Exiting.")


### PR DESCRIPTION
# Description

This PR introduces a number of functional improvements to the annotations pipeline:
- Remove `time.sleep` during sequential automated job runs
- Refactor paths so that paths between tools are mostly not shared
- Fixed some bugs in tool B: 
  - URL query params is now parsing the correct key
  - Fixed bug around merging indices for cases where the highlight range is only one word

Fixes # (issue)
#447 
#446 

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

# Testing

Ran tool B end to end with commands that include reference object annotations, including "build a blue cube".

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

