### PR TITLE
backoff filter, use in interpreting dance filter

### DIFF
--- a/droidlet/interpreter/craftassist/dance.py
+++ b/droidlet/interpreter/craftassist/dance.py
@@ -59,11 +59,13 @@ head_bob = [
 
 def add_default_dances(memory):
     """Add dances to agent's memory"""
-    memory.add_dance(generate_sequential_move_fn(jump), name="jump")
+    memory.add_dance(generate_sequential_move_fn(jump), name="jump", tags=["jump"])
     memory.add_dance(
         generate_sequential_move_fn(konami_dance), name="konami dance", tags=["dance", "konami"]
     )
-    memory.add_dance(generate_sequential_move_fn(head_bob), name="head bob", tags=["dance"])
+    memory.add_dance(
+        generate_sequential_move_fn(head_bob), name="head bob", tags=["dance", "head bob"]
+    )
 
 
 def generate_sequential_move_fn(sequence):

--- a/droidlet/lowlevel/minecraft/cuberite_process.py
+++ b/droidlet/lowlevel/minecraft/cuberite_process.py
@@ -10,8 +10,13 @@ import shutil
 import subprocess
 import tempfile
 import time
-from droidlet.lowlevel.minecraft.craftassist_cuberite_utils import place_blocks, edit_cuberite_config
-from droidlet.lowlevel.minecraft.craftassist_cuberite_utils.wait_for_cuberite import wait_for_cuberite
+from droidlet.lowlevel.minecraft.craftassist_cuberite_utils import (
+    place_blocks,
+    edit_cuberite_config,
+)
+from droidlet.lowlevel.minecraft.craftassist_cuberite_utils.wait_for_cuberite import (
+    wait_for_cuberite,
+)
 from droidlet.lowlevel.minecraft.shape_helpers import build_shape_scene
 
 logging.basicConfig(format="%(asctime)s [%(levelname)s]: %(message)s")
@@ -121,7 +126,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config", default="diverse_world")
+    parser.add_argument("--config", default="flat_world")
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--port", type=int, default=25565)
     parser.add_argument("--logging", action="store_true")

--- a/droidlet/memory/memory_filters.py
+++ b/droidlet/memory/memory_filters.py
@@ -590,6 +590,39 @@ class BasicFilter(MemoryFilter):
         return "Basic: (" + str(self.search_data) + ")"
 
 
+class BackoffFilter(MemoryFilter):
+    """
+    runs a sequence of Filters, passed into the __init__.  if nothing is returned from the 
+    first, returns the results of the second, and so on...
+
+    if a Filter in the sequence is instead a None object, that None object is skipped
+    this can be used to simplify conditional inclusion of a backoff candidate
+    """
+
+    def __init__(self, agent_memory, filters):
+        super().__init__(agent_memory)
+        self.filters = filters
+
+    def search(self):
+        for f in self.filters:
+            if f:
+                memids, vals = f()
+                if memids:
+                    return memids, vals
+        return [], []
+
+    def filter(self, memids, vals):
+        for f in self.filters:
+            if f:
+                filtered_memids, filtered_vals = f(memids, vals)
+                if filtered_memids:
+                    return filtered_memids, filtered_vals
+        return [], []
+
+    def _selfstr(self):
+        return "Backoff (" + str([f for f in self.filters]) + ")"
+
+
 if __name__ == "__main__":
     search_data = {
         "ref_obj_range": {"minx": 3},


### PR DESCRIPTION
# Description

Fixes the "bug" that the agent does not dance when the command is "dance", even though parse is in gt.  this happened because the name of the dance is "dance", and that isn't found because there isn't a dance with that name (dances were not backing off to tags). 

this PR fixes this (and makes possible other backoffs more cleanly) by making a backoff filter that checks for the existence of memories from a sequence of Filters.  if any one Filter returns a memory, the BackoffFilter goes with that.



Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [x] I want a deep design review.

## Before and After

Dances will be found if they are just tagged according to the obj text, even when the parser returns a name search (like reference objects currently)

PR also makes a more general method of doing a backoff that should be used in other places (e.g. Reference objects and GetMemory)

# Testing

ran tests in game

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

