### PR TITLE
[Annotations] Update output dictionary grammar in annotation tools B and C

### DIFF
--- a/tools/annotation_tools/turk_with_s3/construct_final_action_dict.py
+++ b/tools/annotation_tools/turk_with_s3/construct_final_action_dict.py
@@ -107,6 +107,16 @@ def fix_ref_obj(clean_dict):
                     "location": val["location"]
             }
             del val["location"]
+        # Put has_x attributes in triples
+        triples = []
+        for k, v in [x for x in val.items()]:
+            if "has_" in k:
+                triples.append({
+                    "pred_text": k,
+                    "obj_text": v
+                })
+                del val[k]
+        val["triples"] = triples
         new_clean_dict["filters"] = val
     return new_clean_dict
 

--- a/tools/annotation_tools/turk_with_s3/construct_final_action_dict.py
+++ b/tools/annotation_tools/turk_with_s3/construct_final_action_dict.py
@@ -101,6 +101,12 @@ def fix_ref_obj(clean_dict):
         new_clean_dict["repeat"] = val["repeat"]
         val.pop("repeat")
     if val:
+        # Add selectors to filters if there is a location
+        if "location" in val:
+            val["selector"] = {
+                    "location": val["location"]
+            }
+            del val["location"]
         new_clean_dict["filters"] = val
     return new_clean_dict
 

--- a/tools/annotation_tools/turk_with_s3/construct_final_action_dict.py
+++ b/tools/annotation_tools/turk_with_s3/construct_final_action_dict.py
@@ -231,11 +231,14 @@ def fix_spans(d):
         if k == "contains_coreference" and v == "no":
             continue
         if type(v) == list:
-            if k == "tag_val":
-                new_d["has_tag"] = [0, merge_indices(v)]
+            if k != "triples":
+                if k == "tag_val":
+                    new_d["has_tag"] = [0, merge_indices(v)]
+                else:
+                    new_d[k] = [0, merge_indices(v)]
             else:
-                new_d[k] = [0, merge_indices(v)]
-            continue
+                new_d[k] = [fix_spans(x) for x in v]
+                continue
         elif type(v) == dict:
             new_d[k] = fix_spans(v)
             continue

--- a/tools/annotation_tools/turk_with_s3/construct_final_action_dict.py
+++ b/tools/annotation_tools/turk_with_s3/construct_final_action_dict.py
@@ -116,7 +116,8 @@ def fix_ref_obj(clean_dict):
                     "obj_text": v
                 })
                 del val[k]
-        val["triples"] = triples
+        if len(triples) > 0:
+            val["triples"] = triples
         new_clean_dict["filters"] = val
     return new_clean_dict
 

--- a/tools/annotation_tools/turk_with_s3/parse_tool_C_outputs.py
+++ b/tools/annotation_tools/turk_with_s3/parse_tool_C_outputs.py
@@ -339,12 +339,14 @@ def handle_components(d, child_name):
                     del child_d["location"]
                 else:
                     if "reference_object" in child_d["location"]:
-                        child_d["location"]["reference_object"][
-                            "special_reference"
-                        ] = updated_value
+                        child_d["location"]["reference_object"]["special_reference"] = {
+                            "fixed_value": updated_value
+                        }
                     else:
                         child_d["location"]["reference_object"] = {
-                            "special_reference": updated_value
+                            "special_reference": {
+                                "fixed_value": updated_value
+                            }
                         }
 
                     if "coordinates" in child_d["location"]:

--- a/tools/annotation_tools/turk_with_s3/postprocess_part_B.py
+++ b/tools/annotation_tools/turk_with_s3/postprocess_part_B.py
@@ -406,10 +406,10 @@ def handle_components(d, child_name):
                     if "reference_object" in child_d["location"]:
                         child_d["location"]["reference_object"][
                             "special_reference"
-                        ] = updated_value
+                        ] = {"fixed_value": updated_value}
                     else:
                         child_d["location"]["reference_object"] = {
-                            "special_reference": updated_value
+                            "special_reference": {"fixed_value": updated_value}
                         }
 
                     if "coordinates" in child_d["location"]:

--- a/tools/annotation_tools/turk_with_s3/postprocess_part_B.py
+++ b/tools/annotation_tools/turk_with_s3/postprocess_part_B.py
@@ -369,6 +369,14 @@ def handle_components(d, child_name):
         child_d = process_dict(with_prefix(d, "{}.".format("reference_object")))
         output["filters"]["reference_object"].update(child_d)
 
+    elif child_name == "schematic":
+        print(d)
+        child_d = process_dict(with_prefix(d, "{}.".format(child_name)))
+        print(child_d)
+        # Add filters to schematics
+        filters_for_schematics = {"filters": child_d}
+        output[child_name] = filters_for_schematics
+
     elif child_name == "location":
         child_d = process_dict(d)
         # fix location type in location

--- a/tools/annotation_tools/turk_with_s3/postprocess_part_B.py
+++ b/tools/annotation_tools/turk_with_s3/postprocess_part_B.py
@@ -373,8 +373,12 @@ def handle_components(d, child_name):
         print(d)
         child_d = process_dict(with_prefix(d, "{}.".format(child_name)))
         print(child_d)
+        # Convert to triples
+        triples = []
+        for k, v in child_d.items():
+            triples.append({"pred_text": k, "obj_text": v})
         # Add filters to schematics
-        filters_for_schematics = {"filters": child_d}
+        filters_for_schematics = {"filters": {"triples": triples}}
         output[child_name] = filters_for_schematics
 
     elif child_name == "location":
@@ -476,7 +480,7 @@ def remove_definite_articles(cmd, d):
                     new_d[k][k1] = v1
         # for internal nodes
         else:
-            if type(v) == list:
+            if type(v) == list and k != "triples":
                 new_v = []
                 for span in v:
                     # span[0] and span[1] are the same

--- a/tools/annotation_tools/turk_with_s3/postprocess_part_B.py
+++ b/tools/annotation_tools/turk_with_s3/postprocess_part_B.py
@@ -370,15 +370,20 @@ def handle_components(d, child_name):
         output["filters"]["reference_object"].update(child_d)
 
     elif child_name == "schematic":
-        print(d)
         child_d = process_dict(with_prefix(d, "{}.".format(child_name)))
-        print(child_d)
         # Convert to triples
         triples = []
         for k, v in child_d.items():
-            triples.append({"pred_text": k, "obj_text": v})
+            triples.append({
+                "pred_text": k, 
+                "obj_text": v
+            })
         # Add filters to schematics
-        filters_for_schematics = {"filters": {"triples": triples}}
+        filters_for_schematics = {
+            "filters": {
+                "triples": triples
+            }
+        }
         output[child_name] = filters_for_schematics
 
     elif child_name == "location":
@@ -404,12 +409,14 @@ def handle_components(d, child_name):
                     del child_d["location"]
                 else:
                     if "reference_object" in child_d["location"]:
-                        child_d["location"]["reference_object"][
-                            "special_reference"
-                        ] = {"fixed_value": updated_value}
+                        child_d["location"]["reference_object"]["special_reference"] = {
+                            "fixed_value": updated_value
+                        }
                     else:
                         child_d["location"]["reference_object"] = {
-                            "special_reference": {"fixed_value": updated_value}
+                            "special_reference": {
+                                "fixed_value": updated_value
+                            }
                         }
 
                     if "coordinates" in child_d["location"]:


### PR DESCRIPTION
# Description

This PR introduces a number of grammar updates for annotations tools B and C, which handle schematics, location and reference objects.

All changes were made in postprocessing; i.e. there are no Turk task UI changes. UI changes were not necessary for the grammar changes made so far. Some changes are done at the tool outputs postprocessing, some are in the final action dictionary construction `construct_final_action_dict.py`.

The classes of commands we start with supporting are the most popular commands from Turker interactions. These are :

Build X (build a red cube/build a thing/build a house)
Move [direction] (move/move left/move to your left six steps/come here)
Dance (dance/can you do a dance)

Other classes of commands that we've seen:
Destroy [object] (destroy - this is a NOOP/destroy the block in front of you)
Fill [item] (fill a hole/fill it with water)
Dig [object] (dig a hole/dig dirt/dig a rock)

So far we have full support for simple build/move/destroy commands. Some action dictionaries were not affected by grammar changes and do not require updating, eg. basic capabilities ("dance") or "come here".

Specific updates
- Move location in selectors if they are in filters
- Add fixed values to special references
- Add triples to filters
- Move has_x attributes to triples
- Add filters and triples to schematics

It's possible I missed some cases, will continue updating when I see errors in tool outputs.

What the PR does not cover:
- repeats changes
- tool D updates (more complex filters details like comparators, linear extent)

See below for some examples of before/after.

More details in the "Annotations Grammar Update" quip.

Fixes # (issue)
#447 
#446 

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Command: "build a blue cube"
Before:
```
{'action_sequence': [{'action_type': 'BUILD',
                      'schematic': {'has_colour': [0, [2, 2]],
                                    'has_name': [0, [3, 3]]}}],
 'dialogue_type': 'HUMAN_GIVE_COMMAND'}
```

After:
```
{'action_sequence': [{'action_type': 'BUILD',
                      'schematic': {'filters': {'triples': [{'obj_text': [0,
                                                                          [3,
                                                                           3]],
                                                             'pred_text': 'has_name'},
                                                            {'obj_text': [0,
                                                                          [2,
                                                                           2]],
                                                             'pred_text': 'has_colour'}]}}}],
 'dialogue_type': 'HUMAN_GIVE_COMMAND'}
 ```

Command: "move forward 10 steps"
Before:
```
{'action_sequence': [{'action_type': 'MOVE',
                      'location': {'has_measure': [0, [3, 3]],
                                   'reference_object': {'special_reference': 'AGENT'},
                                   'relative_direction': 'FRONT',
                                   'steps': [0, [2, 2]]},
 'dialogue_type': 'HUMAN_GIVE_COMMAND'}           
```

After:
```
{'action_sequence': [{'action_type': 'MOVE',
                      'location': {'reference_object': {'special_reference': {'fixed_value': 'AGENT'}},
                                   'relative_direction': 'FRONT',
                                   'steps': [0, [2, 2]]}}],
 'dialogue_type': 'HUMAN_GIVE_COMMAND'}
```

Command: "destroy the block in front of you"
Before:
```
{'action_sequence': [{'action_type': 'DESTROY',
                      'reference_object': {'filters': {'has_name': [0, [2, 2]],
                                                       'location': {'reference_object': {'special_reference': 'SPEAKER_LOOK'},
                                                                    'relative_direction': 'FRONT'}}}}],
 'dialogue_type': 'HUMAN_GIVE_COMMAND'}
 ```

After:
```
{'action_sequence': [{'action_type': 'DESTROY',
                      'reference_object': {'filters': {'selector': {'location': {'reference_object': {'special_reference': {'fixed_value': 'SPEAKER_LOOK'}},
                                                                                 'relative_direction': 'FRONT'}},
                                                       'triples': [{'obj_text': [0,
                                                                                 [2,
                                                                                  2]],
                                                                    'pred_text': 'has_name'}]}}}],
 ```

Command: "fill a hole"
After:
```
{'action_sequence': [{'action_type': 'FILL',
                      'reference_object': {'filters': {'triples': [{'obj_text': [0,
                                                                                 [2,
                                                                                  2]],
                                                                    'pred_text': 'has_name'}]}}}],
 'dialogue_type': 'HUMAN_GIVE_COMMAND'}
 ```

Command: "dig a hole"
After:
```
dig a hole
{'action_sequence': [{'action_type': 'DIG',
                      'schematic': {'filters': {'triples': [{'obj_text': [0,
                                                                          [2,
                                                                           2]],
                                                             'pred_text': 'has_name'}]}}}],
 'dialogue_type': 'HUMAN_GIVE_COMMAND'}
 ```

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

