### PR TITLE
Dashboard post unification bug fixes

### DIFF
--- a/agents/loco_mc_agent.py
+++ b/agents/loco_mc_agent.py
@@ -7,6 +7,7 @@ import re
 import time
 import numpy as np
 import json
+import os
 import droidlet.event.dispatcher as dispatch
 
 from agents.core import BaseAgent

--- a/droidlet/perception/semantic_parsing/nsp_querier.py
+++ b/droidlet/perception/semantic_parsing/nsp_querier.py
@@ -161,7 +161,7 @@ class NSPQuerier(object):
             logical_form_source = "not_found_in_gt_no_model"
         # log the logical form and chat with source
         self.NSPLogger.log_dialogue_outputs(
-            [chat, logical_form, "semantic_parser", "craftassist", time_now]
+            [chat, logical_form, logical_form_source, "craftassist", time_now]
         )
         # check if logical_form conforms to the grammar
         is_valid_json = self.validate_parse_tree(logical_form)

--- a/droidlet/perception/semantic_parsing/nsp_querier.py
+++ b/droidlet/perception/semantic_parsing/nsp_querier.py
@@ -26,6 +26,9 @@ class NSPQuerier(object):
         self.NSPLogger = NSPLogger(
             "nsp_outputs.csv", ["command", "action_dict", "source", "agent", "time"]
         )
+        self.ErrorLogger = NSPLogger(
+            "error_details.csv", ["command", "action_dict", "time", "parser_error", "other_error", "other_error_description"]
+        )
         try:
             self.parsing_model = DroidletSemanticParsingModel(
                 opts.nsp_models_dir, opts.nsp_data_dir
@@ -47,6 +50,23 @@ class NSPQuerier(object):
             logging.debug("got logical form: %r" % (action_dict))
             payload = {"action_dict": action_dict}
             sio.emit("renderActionDict", payload)
+
+        @sio.on("saveErrorDetailsToCSV")
+        def save_error_details(sid, data):
+            """Save error details to error logs.
+            The fields are
+                ["command", "action_dict", "source", "agent", "time", "parser_error", "other_error", "other_error_description"]
+            """
+            logging.info("Saving error details: %r" % (data))
+            if "action_dict" not in data or "msg" not in data:
+                logging.info("Could not save error details due to error in dashboard backend.")
+                return
+            is_parser_error = data["parsing_error"]
+            if is_parser_error:
+                self.ErrorLogger.log_dialogue_outputs([data["msg"], data["action_dict"], None, True, None, None])
+            else:
+                self.ErrorLogger.log_dialogue_outputs([data["msg"], data["action_dict"], None, False, True, data["feedback"]])
+
 
     def preprocess_chat(self, chat):
         """Tokenize the chat and get list of sentences to parse.
@@ -141,7 +161,7 @@ class NSPQuerier(object):
             logical_form_source = "not_found_in_gt_no_model"
         # log the logical form and chat with source
         self.NSPLogger.log_dialogue_outputs(
-            [chat, logical_form, logical_form_source, "craftassist", time_now]
+            [chat, logical_form, "semantic_parser", "craftassist", time_now]
         )
         # check if logical_form conforms to the grammar
         is_valid_json = self.validate_parse_tree(logical_form)


### PR DESCRIPTION
# Description

Fixes bugs introduced after the dashboard unification.
- Adds missing `os` package import
- Adds Error logger that writes human marked errors to `error_details.csv`

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

# Testing

Ran craftassist agent and cuberite in devfair, accessed dashboard at `http://localhost:8000/turk.html`. All the changes here are backend, no need to build or recompile.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

