### PR TITLE
feed info in StateManager state

### DIFF
--- a/droidlet/dashboard/web/src/StateManager.js
+++ b/droidlet/dashboard/web/src/StateManager.js
@@ -412,7 +412,8 @@ class StateManager {
         }
       }
     });
-    if (!this.curFeedState.rgbImg) {
+    if (this.curFeedState.rgbImg != res) {
+      this.prevFeedState.rgbImg = this.curFeedState.rgbImg
       this.curFeedState.rgbImg = res
     }
   }
@@ -430,7 +431,8 @@ class StateManager {
         }
       }
     });
-    if (!this.curFeedState.depth) {
+    if (this.curFeedState.depth != res) {
+      this.prevFeedState.depth = this.curFeedState.depth
       this.curFeedState.depth = res
     }
   }
@@ -461,8 +463,10 @@ class StateManager {
         });
       }
     });
-    if (!this.curFeedState.masks) {
-      this.curFeedState.masks = res.objects.map(o => o.mask)
+    let masks = res.objects.map(o => o.mask)
+    if (JSON.stringify(this.curFeedState.masks) != JSON.stringify(masks)) {
+      this.prevFeedState.masks = this.curFeedState.masks
+      this.curFeedState.masks = masks
     }
   }
 
@@ -496,27 +500,15 @@ class StateManager {
       }
     });
 
-    // Update feed state here because it's received first
-    if (!this.curFeedState.pose) {
+    if (!this.curFeedState.pose || (res &&  
+      (res.x !== this.curFeedState.pose.x || 
+      res.y !== this.curFeedState.pose.y || 
+      res.yaw !== this.curFeedState.pose.yaw))) {
+      this.prevFeedState.pose = this.curFeedState.pose
       this.curFeedState.pose = {
         x: res.x, 
         y: res.y, 
-        yaw: res.yaw,
-      }
-    } else if (res && 
-      (res.x !== this.curFeedState.pose.x || 
-      res.y !== this.curFeedState.pose.y || 
-      res.yaw !== this.curFeedState.pose.yaw)) {
-      this.prevFeedState = this.curFeedState
-      this.curFeedState = {
-        rgbImg: null, 
-        depthOrg: null, 
-        masks: null, 
-        pose: {
-          x: res.x, 
-          y: res.y, 
-          yaw: res.yaw, 
-        },
+        yaw: res.yaw, 
       }
     }
   }


### PR DESCRIPTION
# Description

Stored the rgb image, depth image, masks, and pose in the StateManager state. The state for the current frame and the last different frame are both stored. Right now, the state is only being maintained and is not used anywhere. 

This PR is to help unblock @jhan6501 so that he can use the state to update mobile annotations. Not all the properties are needed for Jerry, but I also plan on using the state for label propagation in the future so I included the other properties to lower merge conflict costs. 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Testing

Tested locally and confirmed that prevFeedState stores the state from the most recent frame that is different from the current frame. 