### PR TITLE
[polymetis] Fix timestamp representation

### DIFF
--- a/polymetis/polymetis/python/torchcontrol/utils/__init__.py
+++ b/polymetis/polymetis/python/torchcontrol/utils/__init__.py
@@ -3,3 +3,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 from .tensor_utils import *
+from .time_utils import *

--- a/polymetis/polymetis/python/torchcontrol/utils/time_utils.py
+++ b/polymetis/polymetis/python/torchcontrol/utils/time_utils.py
@@ -1,3 +1,7 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 import torch
 
 

--- a/polymetis/polymetis/python/torchcontrol/utils/time_utils.py
+++ b/polymetis/polymetis/python/torchcontrol/utils/time_utils.py
@@ -2,16 +2,53 @@ import torch
 
 
 def timestamp_subtract(ts1, ts2):
+    """ Subtracts two timestamps
+
+    Timestamps are represented as a torch.Tensor of shape (2,), where the first element 
+    corresponds to seconds and the second element corresponds to nanoseconds.
+
+    Args:
+        ts1: First timestamp
+        ts2: Second timestamp
+
+    Outputs:
+        Result of ts1 - ts2 represented as a timestamp
+    """
+    
     assert ts1.shape == torch.Size([2])
     assert ts2.shape == torch.Size([2])
     return ts1 - ts2
 
 
 def timestamp_diff_seconds(ts1, ts2):
+    """ Computes the time difference in seconds between two timestamps.
+
+    Timestamps are represented as a torch.Tensor of shape (2,), where the first element 
+    corresponds to seconds and the second element corresponds to nanoseconds.
+
+    Args:
+        ts1: First timestamp
+        ts2: Second timestamp
+
+    Outputs:
+        Result of ts1 - ts2 in seconds
+    """
     ts_diff = timestamp_subtract(ts1, ts2).to(torch.float32)
     return ts_diff[0] + 1e-9 * ts_diff[1]
 
 
 def timestamp_diff_ms(ts1, ts2):
+    """ Computes the time difference in milliseconds between two timestamps.
+
+    Timestamps are represented as a torch.Tensor of shape (2,), where the first element 
+    corresponds to seconds and the second element corresponds to nanoseconds.
+
+    Args:
+        ts1: First timestamp
+        ts2: Second timestamp
+
+    Outputs:
+        Result of ts1 - ts2 in milliseconds
+    """
     ts_diff = timestamp_subtract(ts1, ts2).to(torch.float32)
     return 1e3 * ts_diff[0] + 1e-6 * ts_diff[1]

--- a/polymetis/polymetis/python/torchcontrol/utils/time_utils.py
+++ b/polymetis/polymetis/python/torchcontrol/utils/time_utils.py
@@ -1,0 +1,17 @@
+import torch
+
+
+def timestamp_subtract(ts1, ts2):
+    assert ts1.shape == torch.Size([2])
+    assert ts2.shape == torch.Size([2])
+    return ts1 - ts2
+
+
+def timestamp_diff_seconds(ts1, ts2):
+    ts_diff = timestamp_subtract(ts1, ts2).to(torch.float32)
+    return ts_diff[0] + 1e-9 * ts_diff[1]
+
+
+def timestamp_diff_ms(ts1, ts2):
+    ts_diff = timestamp_subtract(ts1, ts2).to(torch.float32)
+    return 1e3 * ts_diff[0] + 1e-6 * ts_diff[1]

--- a/polymetis/polymetis/python/torchcontrol/utils/time_utils.py
+++ b/polymetis/polymetis/python/torchcontrol/utils/time_utils.py
@@ -2,9 +2,9 @@ import torch
 
 
 def timestamp_subtract(ts1, ts2):
-    """ Subtracts two timestamps
+    """Subtracts two timestamps
 
-    Timestamps are represented as a torch.Tensor of shape (2,), where the first element 
+    Timestamps are represented as a torch.Tensor of shape (2,), where the first element
     corresponds to seconds and the second element corresponds to nanoseconds.
 
     Args:
@@ -14,16 +14,16 @@ def timestamp_subtract(ts1, ts2):
     Outputs:
         Result of ts1 - ts2 represented as a timestamp
     """
-    
+
     assert ts1.shape == torch.Size([2])
     assert ts2.shape == torch.Size([2])
     return ts1 - ts2
 
 
 def timestamp_diff_seconds(ts1, ts2):
-    """ Computes the time difference in seconds between two timestamps.
+    """Computes the time difference in seconds between two timestamps.
 
-    Timestamps are represented as a torch.Tensor of shape (2,), where the first element 
+    Timestamps are represented as a torch.Tensor of shape (2,), where the first element
     corresponds to seconds and the second element corresponds to nanoseconds.
 
     Args:
@@ -38,9 +38,9 @@ def timestamp_diff_seconds(ts1, ts2):
 
 
 def timestamp_diff_ms(ts1, ts2):
-    """ Computes the time difference in milliseconds between two timestamps.
+    """Computes the time difference in milliseconds between two timestamps.
 
-    Timestamps are represented as a torch.Tensor of shape (2,), where the first element 
+    Timestamps are represented as a torch.Tensor of shape (2,), where the first element
     corresponds to seconds and the second element corresponds to nanoseconds.
 
     Args:

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -77,7 +77,7 @@ Status PolymetisControllerServerImpl::InitRobotClient(
   num_dofs_ = robot_client_metadata->dof();
 
   // Create initial state dictionary
-  timestamp_ = torch::tensor(0.0);
+  timestamp_ = torch::zeros(2).to(torch::kInt32);
   joint_pos_ = torch::zeros(num_dofs_);
   joint_vel_ = torch::zeros(num_dofs_);
 
@@ -150,8 +150,8 @@ PolymetisControllerServerImpl::ControlUpdate(ServerContext *context,
 
   // Parse robot state
   auto timestamp_msg = robot_state->timestamp();
-  auto a = timestamp_.data_ptr<float>();
-  *a = float(timestamp_msg.seconds()) + float(timestamp_msg.nanos()) * 1e-9;
+  timestamp_[0] = timestamp_msg.seconds();
+  timestamp_[1] = timestamp_msg.nanos();
   for (int i = 0; i < num_dofs_; i++) {
     joint_pos_[i] = robot_state->joint_positions(i);
     joint_vel_[i] = robot_state->joint_velocities(i);

--- a/polymetis/tests/scripts/3_timestamps.py
+++ b/polymetis/tests/scripts/3_timestamps.py
@@ -1,0 +1,61 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import time
+from typing import Dict
+
+import torch
+
+from polymetis import RobotInterface
+import torchcontrol as toco
+
+WARMUP_STEPS = 5
+TOTAL_STEPS = 30
+
+
+class TimestampCheckController(toco.PolicyModule):
+    i: int
+    warmup_steps: int
+    total_steps: int
+
+    def __init__(self, hz, warmup_steps, total_steps):
+        super().__init__()
+
+        self.dt = torch.tensor(1.0 / hz)
+        self.warmup_steps = warmup_steps
+        self.total_steps = total_steps
+
+        self.i = 0
+        self.ts_prev = torch.zeros(2).to(torch.int32)
+
+    def forward(self, state_dict: Dict[str, torch.Tensor]):
+        ts = state_dict["timestamp"]
+
+        # Check timestamp
+        if self.i > self.warmup_steps:
+            t_diff = toco.utils.timestamp_diff_seconds(ts, self.ts_prev)
+            assert torch.allclose(t_diff, self.dt, atol=1e-3)  # millisecond accuracy
+
+        # Update
+        self.i += 1
+        self.ts_prev = ts.clone()
+
+        # Termination
+        if self.i > self.total_steps:
+            self.set_terminated()
+
+        return {"torque_desired": torch.zeros(7)}
+
+
+if __name__ == "__main__":
+    # Initialize robot interface
+    robot = RobotInterface(
+        ip_address="localhost",
+    )
+
+    # Run policy
+    policy = TimestampCheckController(
+        hz=robot.metadata.hz, warmup_steps=WARMUP_STEPS, total_steps=TOTAL_STEPS
+    )
+    robot.send_torch_policy(policy)


### PR DESCRIPTION
# Description

Naively converting the timestamp to a float would result in loss of precision, causing time differences to be incorrectly calculated.

- Change the tensor representation of a timestamp to a int32 tensor of size 2, with the first element representing seconds and the second representing nanoseconds.
- Add helper functions to easily obtain time differences between two timestamps.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before this change, timestamps would get converted to the same float value due to [loss of significance](https://en.wikipedia.org/wiki/Loss_of_significance), and thus trying to get differences between timestamps would always result in 0 seconds.

After the change, helper functions return accurate time differences between two timestamps.

# Testing

Add integration test `test/scripts/3_timestamps.py`

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [x] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

