### PR TITLE
[Dashboard in Turk] Fully Automate Dashboard Instance Pool set up

### DIFF
--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/conf/onboarding_example.yaml
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/conf/onboarding_example.yaml
@@ -11,6 +11,12 @@ mephisto:
   task:
     task_title: "Craftassist Task"
     task_description: "Interact with an assistant in a 3-D world creative game."
-    task_reward: 2.0
+    task_reward: 3.0
     task_tags: "static,task,testing"
-    task_name: "droidlet-dashboard"
+    task_name: "droidlet-dashboard-1"
+  architect:
+    heroku_config_args:
+      AWS_ACCESS_KEY_ID: ${env:AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${env:AWS_SECRET_ACCESS_KEY}
+      AWS_DEFAULT_REGION: "us-west-1"
+    heroku_app_name: craftassist-2

--- a/droidlet/tools/crowdsourcing/servermgr/allocate_instances.py
+++ b/droidlet/tools/crowdsourcing/servermgr/allocate_instances.py
@@ -175,6 +175,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--instance_num", type=int, default=1, help="number of instances requested")
     parser.add_argument("--batch_id", type=int, default=0, help="ID of the current batch, used to track which group of runs the task was run in")
+    parser.add_argument("--user", type=str, default="rebeccaqian@fb.com", help="Email of the CloudFlare account")
     args = parser.parse_args()
     instance_ips = request_instance(args.instance_num)
     # register subdomain to proxy instance IP
@@ -182,7 +183,7 @@ if __name__ == "__main__":
         logging.info("registering subdomains on craftassist.io")
         cloudflare_token = os.getenv("CLOUDFLARE_TOKEN")
         zone_id = os.getenv("CLOUDFLARE_ZONE_ID")
-        cf = CloudFlare.CloudFlare(email='rebeccaqian@fb.com', token=cloudflare_token)
+        cf = CloudFlare.CloudFlare(email=args.user, token=cloudflare_token)
         dns_records = cf.zones.dns_records.get(zone_id)
 
         # Write the subdomains and batch IDs to input CSV for Mephisto

--- a/droidlet/tools/crowdsourcing/servermgr/allocate_instances.py
+++ b/droidlet/tools/crowdsourcing/servermgr/allocate_instances.py
@@ -176,8 +176,7 @@ if __name__ == "__main__":
     parser.add_argument("--instance_num", type=int, default=1, help="number of instances requested")
     parser.add_argument("--batch_id", type=int, default=0, help="ID of the current batch, used to track which group of runs the task was run in")
     args = parser.parse_args()
-    # instance_ips = request_instance(args.instance_num)
-    instance_ips = ['54.219.123.69', '3.101.118.112']
+    instance_ips = request_instance(args.instance_num)
     # register subdomain to proxy instance IP
     if os.getenv("CLOUDFLARE_TOKEN") and os.getenv("CLOUDFLARE_ZONE_ID"):
         logging.info("registering subdomains on craftassist.io")

--- a/droidlet/tools/crowdsourcing/servermgr/allocate_instances.py
+++ b/droidlet/tools/crowdsourcing/servermgr/allocate_instances.py
@@ -168,8 +168,11 @@ def register_dashboard_subdomain(cf, zone_id, ip, subdomain):
         return
 
     dns_record = {"name": subdomain, "type": "A", "content": ip, "proxied": True}
-    r = cf.zones.dns_records.post(zone_id, data=dns_record)
-    print("Registered IP {} at subdomain {}".format(ip, subdomain))
+    try:
+        r = cf.zones.dns_records.post(zone_id, data=dns_record)   
+        print("Registered IP {} at subdomain {}".format(ip, subdomain))
+    except Exception as e:
+        raise e 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
# Description

This PR automates more aspects of Turk task set up, so that to set up dashboard and agent environments and run crowdsourced tasks on MTurk, you just need to run two scripts:
1. `allocate_instances.py`: Request <instance_num> ECS instances, register the IPs to Cloudflare DNS with unique subdomains containing a task identifier, write the subdomains and batch number to a CSV for input to the Mephisto pipeline
2. `droidlet_static_html_task/static_run_with_onboarding.py` or `droidlet_static_html_task/static_test_script.py` (no onboarding flow). This runs the Mephisto crowdsourcing tasks with the specified parameters.

Note that this requires several levels of auth, i.e. many environment variables need to be set to allow access to Cloudflare, MTurk, etc.

Fixes # (issue)
#446 
Follow up from #514 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

### Before
Running `allocate_instances.py` prints IP addresses of the newly requested instances. You then need to manually register these to Cloudflare, and specify a new subdomain under *.craftassist.io. You then need to create a `data.csv` for Mephisto task start that looks like

```
subdomain,batch
dashboard-0,7
dashboard-1,7
dashboard-2,7
dashboard-3,7
dashboard-4,7
```

### After
`allocate_instances.py` automatically registers new IPs to Cloudflare and populates `data.csv`, so there is no more manual preprocessing for Turk tasks. 

![Screen Shot 2021-07-07 at 12 10 54 AM](https://user-images.githubusercontent.com/19957918/124717919-6f72a600-deba-11eb-9d31-00adc3c57a4b.png)

# Testing

Kicked off a round of Mephisto Turk tasks in production using the instances pool. 

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

