### PR TITLE
Fix bug introduced in #538

### DIFF
--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -80,7 +80,7 @@ FrankaTorqueControlClient::FrankaTorqueControlClient(
   joint_pos_llimits_ =
       config["limits"]["joint_pos_lower"].as<std::array<double, NUM_DOFS>>();
   joint_vel_limits_ =
-      config["limits"]["joint_velocities"].as<std::array<double, NUM_DOFS>>();
+      config["limits"]["joint_vel"].as<std::array<double, NUM_DOFS>>();
   elbow_vel_limit_ = config["limits"]["elbow_vel"].as<double>();
   joint_torques_limits_ =
       config["limits"]["joint_torques"].as<std::array<double, NUM_DOFS>>();
@@ -91,16 +91,16 @@ FrankaTorqueControlClient::FrankaTorqueControlClient(
   margin_cartesian_pos_ =
       config["safety_controller"]["margins"]["cartesian_pos"].as<double>();
   margin_joint_pos_ =
-      config["safety_controller"]["margins"]["joint_positions"].as<double>();
+      config["safety_controller"]["margins"]["joint_pos"].as<double>();
   margin_joint_vel_ =
-      config["safety_controller"]["margins"]["joint_velocities"].as<double>();
+      config["safety_controller"]["margins"]["joint_vel"].as<double>();
 
   k_cartesian_pos_ =
       config["safety_controller"]["stiffness"]["cartesian_pos"].as<double>();
   k_joint_pos_ =
-      config["safety_controller"]["stiffness"]["joint_positions"].as<double>();
+      config["safety_controller"]["stiffness"]["joint_pos"].as<double>();
   k_joint_vel_ =
-      config["safety_controller"]["stiffness"]["joint_velocities"].as<double>();
+      config["safety_controller"]["stiffness"]["joint_vel"].as<double>();
 }
 
 void FrankaTorqueControlClient::run() {


### PR DESCRIPTION
# Description

Fix issue where certain config fields were accidentally renamed due to having the same name as variables that were targeted in the renaming PR #538
The bug was not caught during the PR since the accidental change happened within the franka_panda_client, which doesn't recompile without setting specific flags.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before this PR running the hardware client would result in a YAML error.
Client runs smoothly after the change.

# Testing

Tested on hardware.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

