### PR TITLE
[polymetis] Automatic recovery for the Franka client

### DIFF
--- a/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
+++ b/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
@@ -20,6 +20,7 @@
 
 #define NUM_DOFS 7
 #define FRANKA_HZ 1000.0
+#define RECOVERY_WAIT_SECS 1
 
 class FrankaTorqueControlClient {
 private:

--- a/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
+++ b/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
@@ -21,6 +21,7 @@
 #define NUM_DOFS 7
 #define FRANKA_HZ 1000.0
 #define RECOVERY_WAIT_SECS 1
+#define RECOVERY_MAX_TRIES 3
 
 class FrankaTorqueControlClient {
 private:

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -127,58 +127,60 @@ void FrankaTorqueControlClient::run() {
     return torque_applied_;
   };
 
-  // Send lambda function
-  bool is_robot_operational = true;
-  while (is_robot_operational) {
-    try {
-      if (!mock_franka_) {
-        robot_ptr_->control(control_callback);
-      } else {
-        franka::RobotState dummy_robot_state;
-        franka::Duration dummy_duration;
-
-        int period = 1.0 / FRANKA_HZ;
-        int period_ns = period * 1.0e9;
-
-        struct timespec abs_target_time;
-        while (true) {
-          clock_gettime(CLOCK_REALTIME, &abs_target_time);
-          abs_target_time.tv_nsec += period_ns;
-
-          control_callback(dummy_robot_state, dummy_duration);
-
-          clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &abs_target_time,
-                          nullptr);
-        }
-      }
-    } catch (const std::exception &ex) {
-      std::cout << ex.what() << std::endl;
-      is_robot_operational = false;
-    }
-
-    // Automatic recovery
-    for (int i = 0; i < RECOVERY_MAX_TRIES; i++) {
-      // Wait
-      if (i == 0) {
-        std::cout << ".\nPerforming automatic error recovery in "
-                  << RECOVERY_WAIT_SECS << " second(s)..." << std::endl;
-      } else {
-        std::cout << ".\nRetrying automatic error recovery in "
-                  << RECOVERY_WAIT_SECS << " second(s)..." << std::endl;
-      }
-      usleep(1000000 * RECOVERY_WAIT_SECS);
-
-      // Attempt recovery
+  // Run robot
+  if (!mock_franka_) {
+    bool is_robot_operational = true;
+    while (is_robot_operational) {
+      // Send lambda function
       try {
-        robot_ptr_->automaticErrorRecovery();
-        std::cout << "Robot operation recovered." << std::endl;
-        is_robot_operational = true;
-        break;
-
+        robot_ptr_->control(control_callback);
       } catch (const std::exception &ex) {
         std::cout << ex.what() << std::endl;
-        std::cout << "Recovery failed. " << std::endl;
+        is_robot_operational = false;
       }
+
+      // Automatic recovery
+      for (int i = 0; i < RECOVERY_MAX_TRIES; i++) {
+        // Wait
+        if (i == 0) {
+          std::cout << ".\nPerforming automatic error recovery in "
+                    << RECOVERY_WAIT_SECS << " second(s)..." << std::endl;
+        } else {
+          std::cout << ".\nRetrying automatic error recovery in "
+                    << RECOVERY_WAIT_SECS << " second(s)..." << std::endl;
+        }
+        usleep(1000000 * RECOVERY_WAIT_SECS);
+
+        // Attempt recovery
+        try {
+          robot_ptr_->automaticErrorRecovery();
+          std::cout << "Robot operation recovered." << std::endl;
+          is_robot_operational = true;
+          break;
+
+        } catch (const std::exception &ex) {
+          std::cout << ex.what() << std::endl;
+          std::cout << "Recovery failed. " << std::endl;
+        }
+      }
+    }
+
+  } else {
+    // Run mocked robot that returns dummy states
+    franka::RobotState dummy_robot_state;
+    franka::Duration dummy_duration;
+
+    int period = 1.0 / FRANKA_HZ;
+    int period_ns = period * 1.0e9;
+
+    struct timespec abs_target_time;
+    while (true) {
+      clock_gettime(CLOCK_REALTIME, &abs_target_time);
+      abs_target_time.tv_nsec += period_ns;
+
+      control_callback(dummy_robot_state, dummy_duration);
+
+      clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &abs_target_time, nullptr);
     }
   }
 }

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -157,10 +157,23 @@ void FrankaTorqueControlClient::run() {
     // Automatic recovery
     std::cout << "Performing automatic error recovery in " << RECOVERY_WAIT_SECS
               << "second(s)..." << std::endl;
-    usleep(RECOVERY_WAIT_USEC);
-    std::cout << "Performing automatic error recovery..." << std::endl;
-    robot_ptr_->automaticErrorRecovery();
-    std::cout << "Robot operation recovered." << std::endl;
+    for (int i = 0; i < RECOVERY_MAX_TRIES; i++) {
+      try {
+        usleep(1000000 * RECOVERY_WAIT_SECS);
+        std::cout << "Performing automatic error recovery..." << std::endl;
+        robot_ptr_->automaticErrorRecovery();
+        std::cout << "Robot operation recovered." << std::endl;
+        break;
+
+      } catch (const std::exception &ex) {
+        std::cout << ex.what() << std::endl;
+        std::cout << "Recovery failed. " << std::endl;
+        if (i < RECOVERY_MAX_TRIES - 1) {
+          std::cout << "Retrying automatic error recovery in "
+                    << RECOVERY_WAIT_SECS << "second(s)..." << std::endl;
+        }
+      }
+    }
   }
 }
 

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -170,7 +170,6 @@ void FrankaTorqueControlClient::run() {
 
       // Attempt recovery
       try {
-        std::cout << "Performing automatic error recovery..." << std::endl;
         robot_ptr_->automaticErrorRecovery();
         std::cout << "Robot operation recovered." << std::endl;
         is_robot_operational = true;

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -156,7 +156,7 @@ void FrankaTorqueControlClient::run() {
 
     // Automatic recovery
     std::cout << "Performing automatic error recovery in " << RECOVERY_WAIT_SECS
-              << "second(s)..." << std::endl;
+              << " second(s)..." << std::endl;
     for (int i = 0; i < RECOVERY_MAX_TRIES; i++) {
       try {
         usleep(1000000 * RECOVERY_WAIT_SECS);
@@ -170,7 +170,7 @@ void FrankaTorqueControlClient::run() {
         std::cout << "Recovery failed. " << std::endl;
         if (i < RECOVERY_MAX_TRIES - 1) {
           std::cout << "Retrying automatic error recovery in "
-                    << RECOVERY_WAIT_SECS << "second(s)..." << std::endl;
+                    << RECOVERY_WAIT_SECS << " second(s)..." << std::endl;
         }
       }
     }

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -160,10 +160,10 @@ void FrankaTorqueControlClient::run() {
     for (int i = 0; i < RECOVERY_MAX_TRIES; i++) {
       // Wait
       if (i == 0) {
-        std::cout << "Performing automatic error recovery in "
+        std::cout << ".\nPerforming automatic error recovery in "
                   << RECOVERY_WAIT_SECS << " second(s)..." << std::endl;
       } else {
-        std::cout << "Retrying automatic error recovery in "
+        std::cout << ".\nRetrying automatic error recovery in "
                   << RECOVERY_WAIT_SECS << " second(s)..." << std::endl;
       }
       usleep(1000000 * RECOVERY_WAIT_SECS);

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -149,21 +149,21 @@ void FrankaTorqueControlClient::run() {
       }
 
       // Automatic recovery
+      std::cout << ".\nPerforming automatic error recovery. This calls "
+                   "franka::Robot::automaticErrorRecovery, which is equivalent "
+                   "to pressing and releasing the external activation device."
+                << std::endl;
       for (int i = 0; i < RECOVERY_MAX_TRIES; i++) {
+        std::cout << "Automatic error recovery attempt " << i + 1 << "/"
+                  << RECOVERY_MAX_TRIES << " ..." << std::endl;
+
         // Wait
-        if (i == 0) {
-          std::cout << ".\nPerforming automatic error recovery in "
-                    << RECOVERY_WAIT_SECS << " second(s)..." << std::endl;
-        } else {
-          std::cout << ".\nRetrying automatic error recovery in "
-                    << RECOVERY_WAIT_SECS << " second(s)..." << std::endl;
-        }
         usleep(1000000 * RECOVERY_WAIT_SECS);
 
         // Attempt recovery
         try {
           robot_ptr_->automaticErrorRecovery();
-          std::cout << "Robot operation recovered." << std::endl;
+          std::cout << "Robot operation recovered.\n." << std::endl;
           is_robot_operational = true;
           break;
 

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -141,9 +141,11 @@ PolymetisControllerServerImpl::ControlUpdate(ServerContext *context,
                                              TorqueCommand *torque_command) {
   // Check if last update is stale
   if (!validRobotContext()) {
-    std::cerr << "Interrupted control update greater than threshold of "
-              << threshold_ns_ << " ns.\n";
-    return Status::CANCELLED;
+    std::cout
+        << "Warning: Interrupted control update greater than threshold of "
+        << threshold_ns_ << " ns. Reverting to default controller...";
+    custom_controller_context_.status = TERMINATING;
+    robot_client_context_.default_controller.get_method("reset")(empty_input_);
   }
 
   // First step of episode: update episode marker

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -148,17 +148,6 @@ PolymetisControllerServerImpl::ControlUpdate(ServerContext *context,
     custom_controller_context_.status = TERMINATING;
   }
 
-  // Parse robot state
-  auto timestamp_msg = robot_state->timestamp();
-  rs_timestamp_[0] = timestamp_msg.seconds();
-  rs_timestamp_[1] = timestamp_msg.nanos();
-  for (int i = 0; i < num_dofs_; i++) {
-    rs_joint_positions_[i] = robot_state->joint_positions(i);
-    rs_joint_velocities_[i] = robot_state->joint_velocities(i);
-    rs_motor_torques_measured_[i] = robot_state->motor_torques_measured(i);
-    rs_motor_torques_external_[i] = robot_state->motor_torques_external(i);
-  }
-
   // Update episode markers
   if (custom_controller_context_.status == READY) {
     // First step of episode: update episode marker
@@ -183,6 +172,17 @@ PolymetisControllerServerImpl::ControlUpdate(ServerContext *context,
     controller = &custom_controller_context_.custom_controller;
   } else {
     controller = &robot_client_context_.default_controller;
+  }
+
+  // Parse robot state
+  auto timestamp_msg = robot_state->timestamp();
+  rs_timestamp_[0] = timestamp_msg.seconds();
+  rs_timestamp_[1] = timestamp_msg.nanos();
+  for (int i = 0; i < num_dofs_; i++) {
+    rs_joint_positions_[i] = robot_state->joint_positions(i);
+    rs_joint_velocities_[i] = robot_state->joint_velocities(i);
+    rs_motor_torques_measured_[i] = robot_state->motor_torques_measured(i);
+    rs_motor_torques_external_[i] = robot_state->motor_torques_external(i);
   }
 
   // Step controller & generate torque command response

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -148,6 +148,10 @@ PolymetisControllerServerImpl::ControlUpdate(ServerContext *context,
     custom_controller_context_.status = TERMINATING;
   }
 
+  // Lock to prevent external termination during controller selection, which
+  // might cause loading of a uninitialized default controller
+  service_mtx_.lock();
+
   // Update episode markers
   if (custom_controller_context_.status == READY) {
     // First step of episode: update episode marker
@@ -173,6 +177,9 @@ PolymetisControllerServerImpl::ControlUpdate(ServerContext *context,
   } else {
     controller = &robot_client_context_.default_controller;
   }
+
+  // Unlock
+  service_mtx_.unlock();
 
   // Parse robot state
   auto timestamp_msg = robot_state->timestamp();

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -143,7 +143,8 @@ PolymetisControllerServerImpl::ControlUpdate(ServerContext *context,
   if (!validRobotContext()) {
     std::cout
         << "Warning: Interrupted control update greater than threshold of "
-        << threshold_ns_ << " ns. Reverting to default controller...";
+        << threshold_ns_ << " ns. Reverting to default controller..."
+        << std::endl;
     custom_controller_context_.status = TERMINATING;
   }
 

--- a/polymetis/polymetis/tests/cpp/test_server.cpp
+++ b/polymetis/polymetis/tests/cpp/test_server.cpp
@@ -124,7 +124,7 @@ TEST_F(ServiceTest, SetController) {
                                       dummy_robot_state_, new TorqueCommand)
                       .ok());
 
-      if (i == 1) {
+      if (i == 2) {
         terminate_mtx.unlock();
         usleep(100000);
       }


### PR DESCRIPTION
# Description

Enable the Franka Panda client to attempt to recover automatically from an error instead of exiting.

### Changes:
- Wrap command that runs the robot within a loop that attempts to recover using `franka::Robot::automaticErrorRecovery` when an error occurs.
- Update PolymetisServer to re-launch a default controller instead of exiting when a stale robot client is detected.
- Update test to reflect the external termination service that is now one step faster due to changes in PolymetisServer.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before the changes implemented, the franka client would run to a halt whenever an error is encountered, which is usually due to a safety constraint violation.
![Screen Shot 2021-07-09 at 3 13 11 PM](https://user-images.githubusercontent.com/9565466/125140800-31e36800-e0c8-11eb-9e6a-6257e085d73d.png)

After the changes, the client now attempts to reconnect to the robot and return to an operational state by launching a default controller from the new state.
![Screen Shot 2021-07-09 at 3 11 11 PM](https://user-images.githubusercontent.com/9565466/125140706-fa74bb80-e0c7-11eb-8bb2-857beb4708ad.png)

# Testing

Tested on hardware.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

