### PR TITLE
Hollis/save annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ agents/locobot/dashboard_data.db
 droidlet/perception/robot/tests/test_assets/perception_handlers
 .ropeproject
 agents/craftassist/timeline_log*
+annotation_data/*

--- a/agents/locobot/locobot_agent.py
+++ b/agents/locobot/locobot_agent.py
@@ -165,14 +165,17 @@ class LocobotAgent(LocoMCAgent):
             # Convert mask points to mask maps then combine them
             categories = postData["categories"]
             src_label = np.zeros((height, width)).astype(int)
-            for o in postData["prevObjects"]: 
+            # For display only -- 2 separate chair masks will be same color here
+            display_map = np.zeros((height, width)).astype(int) 
+            for n, o in enumerate(postData["prevObjects"]): 
                 poly = Polygons(o["mask"])
                 bitmap = poly.mask(height, width) # not np array
                 index = categories.index(o["label"])
                 for i in range(height): 
                     for j in range(width): 
                         if bitmap[i][j]: 
-                            src_label[i][j] = index
+                            src_label[i][j] = n + 1
+                            display_map[i][j] = index
 
             # Attach base pose data
             pose = postData["prevBasePose"]
@@ -197,7 +200,7 @@ class LocobotAgent(LocoMCAgent):
             # Save annotation data to disk for retraining
             Path("annotation_data/seg").mkdir(parents=True, exist_ok=True)
             Path("annotation_data/rgb").mkdir(parents=True, exist_ok=True)
-            np.save("annotation_data/seg/{:05d}.npy".format(postData["frameCount"]), src_label)
+            np.save("annotation_data/seg/{:05d}.npy".format(postData["frameCount"]), display_map)
             im = Image.fromarray(src_img)
             im.save("annotation_data/rgb/{:05d}.jpg".format(postData["frameCount"]))
 

--- a/droidlet/dashboard/web/src/StateManager.js
+++ b/droidlet/dashboard/web/src/StateManager.js
@@ -405,6 +405,16 @@ class StateManager {
       let oldObj = id < this.curFeedState.objects.length;
       let newId = oldObj ? this.curFeedState.objects[id].id : null;
       let newXyz = oldObj ? this.curFeedState.objects[id].xyz : null;
+      // Get rid of masks with <3 points
+      // We have this check because detector sometimes sends masks with <3 points to frontend
+      let i = 0
+      while (i < pointMap[id].length) {
+        if (!pointMap[id][i] || pointMap[id][i].length < 3) {
+          pointMap[id].splice(i, 1);
+          continue
+        }
+        i++
+      }
       let newMask = pointMap[id].map(mask => mask.map((pt, i) => [pt.x * scale, pt.y * scale]))
       let newBbox = this.getNewBbox(newMask);
 

--- a/droidlet/dashboard/web/src/StateManager.js
+++ b/droidlet/dashboard/web/src/StateManager.js
@@ -85,6 +85,7 @@ class StateManager {
     this.onObjectAnnotationSave = this.onObjectAnnotationSave.bind(this);
     this.startLabelPropagation = this.startLabelPropagation.bind(this);
     this.labelPropagationReturn = this.labelPropagationReturn.bind(this);
+    this.saveAnnotations = this.saveAnnotations.bind(this);
 
     // set turk related params
     const urlParams = new URLSearchParams(window.location.search);
@@ -127,6 +128,8 @@ class StateManager {
       objects: false,
       pose: false,
     }
+    this.frameCount = 0
+    this.categories = new Set()
   }
 
   setDefaultUrl() {
@@ -442,13 +445,19 @@ class StateManager {
   }
 
   startLabelPropagation() {
+    let prevObjects = this.prevFeedState.objects.filter(o => o.type === "annotate")
+    for (let i in prevObjects) {
+      this.categories.add(prevObjects[i].label)
+    }
     let props = {
       prevRgbImg: this.prevFeedState.rgbImg, 
       depth: this.curFeedState.depth, 
       prevDepth: this.prevFeedState.depth, 
-      prevObjects: this.prevFeedState.objects.filter(o => o.type === "annotate"), 
+      prevObjects: prevObjects, 
       basePose: this.curFeedState.pose,
       prevBasePose: this.prevFeedState.pose,
+      frameCount: this.frameCount,
+      categories: [null, ...this.categories], // Include null so category indices start at 1
     }
     this.socket.emit("label_propagation", props)
     // Reset
@@ -456,6 +465,7 @@ class StateManager {
     this.stateProcessed.depth = true;
     this.stateProcessed.objects = true;
     this.stateProcessed.pose = true;
+    this.frameCount++
   }
 
   labelPropagationReturn(res) {
@@ -494,6 +504,11 @@ class StateManager {
       !this.stateProcessed.objects && 
       !this.stateProcessed.pose  
     )
+  }
+
+  saveAnnotations() {
+    let categories = [null, ...this.categories] // Include null so category indices start at 1
+    this.socket.emit("save_annotations", categories)
   }
 
   processMemoryState(msg) {

--- a/droidlet/dashboard/web/src/components/LiveObjects.js
+++ b/droidlet/dashboard/web/src/components/LiveObjects.js
@@ -32,6 +32,7 @@ class LiveObjects extends React.Component {
     this.addObject = this.addObject.bind(this);
     this.onResize = this.onResize.bind(this);
     this.onFixup = this.onFixup.bind(this);
+    this.onAnnotationSave = this.onAnnotationSave.bind(this);
     this.initialState = {
       height: props.height,
       width: props.width,
@@ -97,6 +98,12 @@ class LiveObjects extends React.Component {
           }
         }
       }
+    }
+  }
+
+  onAnnotationSave() {
+    if (this.props.stateManager) {
+      this.props.stateManager.saveAnnotations()
     }
   }
 
@@ -212,6 +219,7 @@ class LiveObjects extends React.Component {
           </Layer>
         </Stage>
         <button onClick={this.onFixup}>Fix</button>
+        <button onClick={this.onAnnotationSave}>Save</button>
       </Rnd>
     );
   }


### PR DESCRIPTION
# Description

Adds a button to save annotations in COCO format onto the disk. This is the groundwork for retraining the detector, as the training process uses images in the COCO format. 

The annotations saved include the results from label prop and any annotations the user manually saves, and they are saved into a folder called annotation_data on the root folder. The image and segmentation data are saved right before label propagation is run. This gives users the chance to edit any poor masks from label prop before saving the annotations to disk. 

The code on the backend to convert annotations to COCO format was adapted from coco_creator.ipynb. 

## Before and After

Before, users could not save annotations -- now they can press the "Save" button to save the annotations to disk. 

Before: 
![image](https://user-images.githubusercontent.com/44927209/125956463-7e63e74b-4932-4d8f-83a5-83ef9ed40c19.png)

After: 
![image](https://user-images.githubusercontent.com/44927209/125956323-71cb442a-e4c5-4e3c-8835-3d3997893c7c.png)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

# Testing

I tested by fixing sets of annotations and pressing the "Save" button and manually verifying that the image, segmentation, and json files exist. I also verified that the resulting json file has the correct annotation info on pycoco_locobot.ipynb. 

Displaying an annotation from the resulting COCO json file: 
![image](https://user-images.githubusercontent.com/44927209/125958337-c23ae7ea-e07e-408a-8a27-c23bebdddfe1.png)

## Limitation

The annotation_tools/ folder needs to be deleted each refresh. Ideally, should delete the folder on startup. Need to figure out where to do this. 

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

