### PR TITLE
Added a bug fix for TypeError in dashboard timeline

### DIFF
--- a/droidlet/dashboard/web/src/components/Timeline/TimelineResults.js
+++ b/droidlet/dashboard/web/src/components/Timeline/TimelineResults.js
@@ -14,12 +14,13 @@ class TimelineResults extends React.Component {
   render() {
     return (
       <div className="subpanel">
-        {this.props.stateManager.memory.timelineSearchResults.map((item) => (
-          <div>
-            {renderTable(jsonToArray(item))}
-            <hr />
-          </div>
-        ))}
+        {this.props.stateManager.memory.timelineSearchResults &&
+          this.props.stateManager.memory.timelineSearchResults.map((item) => (
+            <div>
+              {renderTable(jsonToArray(item))}
+              <hr />
+            </div>
+          ))}
       </div>
     );
   }


### PR DESCRIPTION
# Description

This PR fixes the "TypeError: Cannot read property 'map' of undefined" in the dashboard timeline.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

# Testing

Tested manually with the dashboard and CraftAssist.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

