### PR TITLE
label prop works with small yaw

### DIFF
--- a/agents/locobot/locobot_agent.py
+++ b/agents/locobot/locobot_agent.py
@@ -104,20 +104,24 @@ class LocobotAgent(LocoMCAgent):
         super().init_event_handlers()
 
         @sio.on("movement command")
-        def test_command(sid, commands):
+        def test_command(sid, commands, movement_values={}):
+            if len(movement_values) == 0: 
+                movement_values["yaw"] = 0.01
+                movement_values["velocity"] = 0.1
+
             movement = [0.0, 0.0, 0.0]
             for command in commands:
                 if command == "MOVE_FORWARD":
-                    movement[0] += 0.1
+                    movement[0] += movement_values["velocity"]
                     print("action: FORWARD")
                 elif command == "MOVE_BACKWARD":
-                    movement[0] -= 0.1
+                    movement[0] -= movement_values["velocity"]
                     print("action: BACKWARD")
                 elif command == "MOVE_LEFT":
-                    movement[2] += 0.01
+                    movement[2] += movement_values["yaw"]
                     print("action: LEFT")
                 elif command == "MOVE_RIGHT":
-                    movement[2] -= 0.01
+                    movement[2] -= movement_values["yaw"]
                     print("action: RIGHT")
                 elif command == "PAN_LEFT":
                     self.mover.bot.set_pan(self.mover.bot.get_pan() + 0.08)

--- a/agents/locobot/locobot_agent.py
+++ b/agents/locobot/locobot_agent.py
@@ -114,10 +114,10 @@ class LocobotAgent(LocoMCAgent):
                     movement[0] -= 0.1
                     print("action: BACKWARD")
                 elif command == "MOVE_LEFT":
-                    movement[2] += 0.3
+                    movement[2] += 0.01
                     print("action: LEFT")
                 elif command == "MOVE_RIGHT":
-                    movement[2] -= 0.3
+                    movement[2] -= 0.01
                     print("action: RIGHT")
                 elif command == "PAN_LEFT":
                     self.mover.bot.set_pan(self.mover.bot.get_pan() + 0.08)

--- a/droidlet/dashboard/web/src/StateManager.js
+++ b/droidlet/dashboard/web/src/StateManager.js
@@ -16,6 +16,7 @@ import TimelineResults from "./components/Timeline/TimelineResults";
 import TimelineDetails from "./components/Timeline/TimelineDetails";
 import MobileMainPane from "./MobileMainPane";
 import Retrainer from "./components/Retrainer";
+import Navigator from "./components/Navigator";
 import { isMobile } from "react-device-detect";
 
 /**
@@ -391,7 +392,14 @@ class StateManager {
       }
     }
     if (commands.length > 0) {
-      this.socket.emit("movement command", commands);
+      let movementValues = {};
+      this.refs.forEach((ref) => {
+        if (ref instanceof Navigator) {
+          movementValues = ref.state;
+        }
+      });
+
+      this.socket.emit("movement command", commands, movementValues);
 
       // Reset keys to prevent duplicate commands
       for (let i in keys) {

--- a/droidlet/dashboard/web/src/components/Navigator.js
+++ b/droidlet/dashboard/web/src/components/Navigator.js
@@ -4,6 +4,12 @@ Copyright (c) Facebook, Inc. and its affiliates.
 
 import React from "react";
 import stateManager from "../StateManager";
+import "status-indicator/styles.css";
+import Slider from "rc-slider";
+import "rc-slider/assets/index.css";
+
+let slider_style = { width: 600, margin: 50 };
+const labelStyle = { minWidth: "60px", display: "inline-block" };
 
 /**
  * Currently just a keybinding wrapper that hooks
@@ -15,9 +21,16 @@ import stateManager from "../StateManager";
 class Navigator extends React.Component {
   constructor(props) {
     super(props);
+    this.initialState = {
+      yaw: 0.01, 
+      velocity: 0.1,
+    }
 
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.onYawChange = this.onYawChange.bind(this);
+    this.onVelocityChange = this.onVelocityChange.bind(this);
     this.navRef = React.createRef();
+    this.state = this.initialState
   }
 
   handleSubmit(event) {
@@ -26,6 +39,7 @@ class Navigator extends React.Component {
   }
 
   componentDidMount() {
+    if (stateManager) stateManager.connect(this);
     var map = {};
     var onkey = function (e) {
       map[e.keyCode] = true;
@@ -35,10 +49,44 @@ class Navigator extends React.Component {
     setInterval(stateManager.keyHandler, interval, map); // keyHandler gets called every interval milliseconds
   }
 
+  onYawChange(value) {
+    this.setState({ yaw: value })
+  }
+
+  onVelocityChange(value) {
+    this.setState({ velocity: value })
+  }
+
   render() {
     return (
       <div ref={this.navRef}>
         <p> Use the arrow keys to move the robot around</p>
+        <div style={slider_style}>
+          <label style={labelStyle}>Yaw: &nbsp;</label>
+          <span>{this.state.yaw}</span>
+          <br />
+          <br />
+          <Slider
+              value={this.state.yaw}
+              min={0}
+              max={0.5}
+              step={0.01}
+              onChange={this.onYawChange}
+          />
+        </div>
+        <div style={slider_style}>
+            <label style={labelStyle}>Velocity: &nbsp;</label>
+            <span>{this.state.velocity}</span>
+            <br />
+            <br />
+            <Slider
+                value={this.state.velocity}
+                min={0}
+                max={1}
+                step={0.05}
+                onChange={this.onVelocityChange}
+            />
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
# Description

Label propagation currently doesn't work well because of how much the agent turns with each MOVE_LEFT or MOVE_RIGHT command. The larger the yaw difference between the two frames, the worse label propagation gets. 

From top to bottom, we have the original label map, yaw of 0.01, 0.05, 0.1, 0.2, and 0.3. The current dashboard changes by 0.3 with each turn, which is why label prop works so poorly. 

![image](https://user-images.githubusercontent.com/44927209/128395029-cc8c24f2-3bef-4029-8649-c34083627bee.png)

One caveat is that the depth map for most of the above values do not align, but smaller yaw deltas clearly have significant impact. In this PR, I set the yaw change to be 0.01. Below is a gif of how label prop looks with this change. 

![Screen Recording 2021-08-05 at 1 24 41 PM](https://user-images.githubusercontent.com/44927209/128394688-bbf2aab7-9f88-4eae-bdbd-a41b95b1be11.gif)

The reason 0.01 was chosen is because 0.05 performs poorly, and 0.02 is alright for the next frame but devolves on the third frame. It would be a good idea to have some sort of input so that the user can specify how much the agent should turn. 

Update: included sliders for changing the yaw and also the velocity (how far agent goes when moving forward and backward). 