### PR TITLE
only run label prop when necessary

### DIFF
--- a/droidlet/dashboard/web/src/StateManager.js
+++ b/droidlet/dashboard/web/src/StateManager.js
@@ -501,15 +501,17 @@ class StateManager {
     }
 
     // Label prop
-    let labelProps = {
-      prevRgbImg: this.prevFeedState.rgbImg, 
-      depth: this.curFeedState.depth, 
-      prevDepth: this.prevFeedState.depth, 
-      objects: prevObjects, 
-      basePose: this.curFeedState.pose,
-      prevBasePose: this.prevFeedState.pose,
+    if (prevObjects.length > 0) {
+      let labelProps = {
+        prevRgbImg: this.prevFeedState.rgbImg, 
+        depth: this.curFeedState.depth, 
+        prevDepth: this.prevFeedState.depth, 
+        objects: prevObjects, 
+        basePose: this.curFeedState.pose,
+        prevBasePose: this.prevFeedState.pose,
+      }
+      this.socket.emit("label_propagation", labelProps)
     }
-    this.socket.emit("label_propagation", labelProps)
 
     // Save rgb/seg if needed
     if (!this.annotationsSaved) {


### PR DESCRIPTION
# Description

Label prop is run every frame change, even frames where no objects should be returned, which may break certain pipelines. This PR introduces a change to only run label prop when there are annotated objects. 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

# Testing

Run locobot agent and move with and without annotations and views the socket events sent or print when label prop is run. 

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

