### PR TITLE
remove convert_location_to_selector

### DIFF
--- a/droidlet/interpreter/__init__.py
+++ b/droidlet/interpreter/__init__.py
@@ -8,7 +8,6 @@ from .interpreter_utils import (
     tags_from_dict,
     strip_prefix,
     ref_obj_lf_to_selector,
-    convert_location_to_selector,
 )
 
 from .reference_object_helpers import (
@@ -34,7 +33,6 @@ __all__ = [
     SPEAKERPOS,
     AGENTPOS,
     ref_obj_lf_to_selector,
-    convert_location_to_selector,
     is_loc_speakerlook,
     coref_resolve,
     process_spans_and_remove_fixed_value,

--- a/droidlet/interpreter/craftassist/mc_interpreter.py
+++ b/droidlet/interpreter/craftassist/mc_interpreter.py
@@ -18,7 +18,6 @@ from droidlet.interpreter import (
     get_repeat_num,
     filter_by_sublocation,
     interpret_dance_filter,
-    convert_location_to_selector,
 )
 
 from .schematic_helper import (
@@ -218,7 +217,6 @@ class MCInterpreter(Interpreter):
             # handle copy
             ##########FIXME remove this when DSL updated!!!
             md = deepcopy(d)
-            convert_location_to_selector(md["reference_object"])
             objs = self.subinterpret["reference_objects"](
                 self,
                 speaker,

--- a/droidlet/interpreter/interpreter_utils.py
+++ b/droidlet/interpreter/interpreter_utils.py
@@ -22,26 +22,6 @@ def ref_obj_lf_to_selector(ref_obj_dict):
     return s
 
 
-# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# FIXME temporary torch this, should not be here after june 2021
-# will not do anything if a selector is already in place
-# also doesn't convert locations properly, as LinearExtent is not nesting
-# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-def convert_location_to_selector(lf):
-    if type(lf) is not dict:
-        return
-    for k, v in lf.items():
-        if k == "filters":
-            if not v.get("selector"):
-                if v.get("location", {}).get("reference_object"):
-                    r = v["location"]["reference_object"]
-                    selector_d = ref_obj_lf_to_selector({"reference_object": r})
-                    del v["location"]
-                    v["selector"] = selector_d
-        else:
-            convert_location_to_selector(v)
-
-
 def maybe_listify_tags(t):
     return [t] if type(t) is str else t
 

--- a/droidlet/interpreter/tests/test_interpreter_utils.py
+++ b/droidlet/interpreter/tests/test_interpreter_utils.py
@@ -9,7 +9,7 @@ from droidlet.perception.semantic_parsing.tests.test_y_print_parsing_report impo
     common_functional_commands,
     compare_full_dictionaries,
 )
-from all_test_commands import INTERPRETER_POSSIBLE_ACTIONS, FILTERS, REFERENCE_OBJECTS
+from .all_test_commands import INTERPRETER_POSSIBLE_ACTIONS, FILTERS, REFERENCE_OBJECTS
 
 logical_form_before_processing = {
     "turn right": common_functional_commands["turn right"],
@@ -46,7 +46,7 @@ logical_form_post_processing = {
 }
 
 
-class TestProcessSpans(unittest.TestCase):
+class TestInterpreterUtils(unittest.TestCase):
     def test_process_spans(self):
         for k, v in logical_form_before_processing.items():
             processed = deepcopy(v)
@@ -57,21 +57,20 @@ class TestProcessSpans(unittest.TestCase):
             )  # process spans and fixed_values. Implemented in: interpreter_utils.
             assert compare_full_dictionaries(processed, logical_form_post_processing[k])
 
-class TestLocationInSelector(unittest.TestCase):
-    def check_location_in_filters(self, action_dict):
-        for key, value in action_dict.items():
-            if key == "filters" and "location" in value:
-                return False
-            elif type(value) == dict:
-                return self.check_location_in_filters(value)
-        return True
-
     def test_location_reference_object(self):
+        def check_location_in_filters(action_dict):
+            for key, value in action_dict.items():
+                if key == "filters" and "location" in value:
+                    return False
+                elif type(value) == dict:
+                    return check_location_in_filters(value)
+            return True
+
         all_dicts = INTERPRETER_POSSIBLE_ACTIONS
         all_dicts.update(FILTERS)
         all_dicts.update(REFERENCE_OBJECTS)
         for key, action_dict in all_dicts.items():
-            self.assertTrue(self.check_location_in_filters(action_dict))
+            self.assertTrue(check_location_in_filters(action_dict))
 
 
 

--- a/droidlet/interpreter/tests/test_interpreter_utils.py
+++ b/droidlet/interpreter/tests/test_interpreter_utils.py
@@ -9,6 +9,7 @@ from droidlet.perception.semantic_parsing.tests.test_y_print_parsing_report impo
     common_functional_commands,
     compare_full_dictionaries,
 )
+from all_test_commands import INTERPRETER_POSSIBLE_ACTIONS, FILTERS, REFERENCE_OBJECTS
 
 logical_form_before_processing = {
     "turn right": common_functional_commands["turn right"],
@@ -55,6 +56,23 @@ class TestProcessSpans(unittest.TestCase):
                 processed, original_words, lemmatized_words
             )  # process spans and fixed_values. Implemented in: interpreter_utils.
             assert compare_full_dictionaries(processed, logical_form_post_processing[k])
+
+class TestLocationInSelector(unittest.TestCase):
+    def check_location_in_filters(self, action_dict):
+        for key, value in action_dict.items():
+            if key == "filters" and "location" in value:
+                return False
+            elif type(value) == dict:
+                return self.check_location_in_filters(value)
+        return True
+
+    def test_location_reference_object(self):
+        all_dicts = INTERPRETER_POSSIBLE_ACTIONS
+        all_dicts.update(FILTERS)
+        all_dicts.update(REFERENCE_OBJECTS)
+        for key, action_dict in all_dicts.items():
+            self.assertTrue(self.check_location_in_filters(action_dict))
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Removes the intermediate patch of `convert_location_to_selector`.
The grammar now supports this and this codemod is unnecessary. Also added a unit test.

Fixes #618 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

# Testing
Tested locally and on CI.
Also added a unit test

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [x] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.

